### PR TITLE
Add configurable spec ID prefix methods

### DIFF
--- a/.agents/skills/spek-new/SKILL.md
+++ b/.agents/skills/spek-new/SKILL.md
@@ -5,7 +5,7 @@ description: Create a new Specification for a feature.
 
 # What this skill does
 
-This skill drives a **multi-step interactive workflow** that produces a complete specification file in `.spektacular/specs/<name>.md`. The workflow is owned by the `go run .` CLI, not by you — the CLI is the state machine and you are the executor.
+This skill drives a **multi-step interactive workflow** that produces a complete specification file at the `spec_path` returned by the CLI. The workflow is owned by the `go run .` CLI, not by you — the CLI is the state machine and you are the executor.
 
 On each turn, the CLI returns JSON containing an `instruction` field. That instruction describes exactly one step (e.g. overview, requirements, acceptance criteria, …). You must:
 
@@ -27,5 +27,13 @@ Start the spec workflow by running:
 ```
 go run . spec new --data '{"name": "<spec_name>"}'
 ```
+
+External systems may also supply an identifier with:
+
+```
+go run . spec new --data '{"name": "<spec_name>", "id": "<external_id>"}'
+```
+
+The CLI may normalize and prefix the requested name. Always use the returned `spec_name` and `spec_path` as the source of truth for follow-up workflows.
 
 This creates the spec file and state file automatically and returns the first `instruction`. From that point on, follow the loop above: do what the instruction says, then call `go run . spec goto --data '{"step":"<next_step>"}'` to get the next one. Do not invent step names — every instruction tells you the exact `goto` command to run next.

--- a/.github/workflows/build_and_deploy.yaml
+++ b/.github/workflows/build_and_deploy.yaml
@@ -3,24 +3,30 @@ on:
   push:
     branches:
       - "**"
+  pull_request:
+    branches:
+      - main
+
 jobs:
-  dagger_build:
+  build:
     name: Dagger Build and Test
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
 
     steps:
       - uses: actions/checkout@v4
 
       - name: Set keys
+        if: ${{ github.repository == 'jumppad-labs/spektacular' && github.event_name == 'push' }}
         run: |
           echo "${{secrets.QUILL_SIGN_P12}}" | base64 -d  > ./cert.p12
           echo "${{secrets.QUILL_NOTORY_KEY}}" > ./key.p8
           echo "QUILL_SIGN_PASSWORD=${{secrets.QUILL_SIGN_PASSWORD}}" >> $GITHUB_ENV
           echo "GITHUB_TOKEN=${{secrets.GH_TOKEN}}" >> $GITHUB_ENV
-      
-      - name: All
+
+      - name: All signed
+        if: ${{ github.repository == 'jumppad-labs/spektacular' && github.event_name == 'push' }}
         uses: dagger/dagger-for-github@v8.2.0
         with:
           verb: call
@@ -28,29 +34,41 @@ jobs:
           args: all --output=./output --src=. --github-token=GITHUB_TOKEN --notorize-cert=./cert.p12 --notorize-cert-password=QUILL_SIGN_PASSWORD --notorize-key=./key.p8 --notorize-id=${{secrets.QUILL_NOTARY_KEY_ID}} --notorize-issuer=${{secrets.QUILL_NOTARY_ISSUER}}
           version: "0.19.8"
           dagger-flags: "--progress=plain"
-      
+
+      - name: All unsigned
+        if: ${{ github.repository != 'jumppad-labs/spektacular' || github.event_name != 'push' }}
+        uses: dagger/dagger-for-github@v8.2.0
+        with:
+          verb: call
+          module: ./dagger
+          args: all --output=./output --src=.
+          version: "0.19.8"
+          dagger-flags: "--progress=plain"
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: archives
           path: |
             ./output
-  
+
   release:
     name: Create GitHub Release
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ github.repository == 'jumppad-labs/spektacular' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
-    needs: 
-      - dagger_build
+    needs:
+      - build
     environment:
       name: release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Set keys
         run: |
           echo "GITHUB_TOKEN=${{secrets.GH_TOKEN}}" >> $GITHUB_ENV
           echo "GEMFURY_TOKEN=${{secrets.FURY_TOKEN}}" >> $GITHUB_ENV
-      
+
       - uses: actions/checkout@v4
 
       - name: Download-Binaries
@@ -67,7 +85,7 @@ jobs:
           args: release --src=. --github-token=GITHUB_TOKEN --gemfury-token=GEMFURY_TOKEN --archives=./build_artifacts --output=./version.txt
           version: "0.19.8"
           dagger-flags: "--progress=plain"
-    
+
       - name: Set output
         id: setoutput
         run: |

--- a/.spektacular/plans/spec-id-prefix-method/context.md
+++ b/.spektacular/plans/spec-id-prefix-method/context.md
@@ -1,0 +1,167 @@
+# Context: spec-id-prefix-method
+
+## Current State Analysis
+
+- `cmd/spec.go:19` defines `nameRegexp` as lowercase alphanumeric plus hyphen/underscore. It currently validates only the requested spec name, not an external identifier.
+- `cmd/spec.go:136-197` owns `spec new`: it reports schema, parses `--data`, validates `name`, loads config, removes the shared state file for non-dry-run creation, creates a workflow with `store.NewFileStore(dataDir)`, and sets workflow data key `name` to the parsed input name.
+- `cmd/spec.go:137-148` reports a schema with only `name` as input, so external callers cannot discover an `id` field yet.
+- `cmd/spec.go:176-187` removes state before workflow creation and then sets `name` directly from input. New validation must happen before state removal so validation failures do not clobber active state.
+- `cmd/spec.go:259-292` builds status paths from the workflow data `name`, so putting the canonical name in state makes status output naturally follow the new naming behavior.
+- `internal/steps/spec/steps.go:11-14` builds the store-relative spec path as `specs/<name>.md`.
+- `internal/steps/spec/steps.go:63-80` writes the initial scaffold for `new()` using the workflow data `name`; it should not need to know which identifier method was used.
+- `internal/steps/spec/strategy.go:14-18` reports `spec_path` and `spec_name` from the workflow name. This supports resolving the final name before workflow start.
+- `internal/config/config.go:18-32` defines the top-level config and defaults. `FromYAMLFile` unmarshals into `NewDefault()`, so missing fields can inherit defaults.
+- `internal/config/config_test.go:11-49` covers default values, env expansion, missing-file errors, and round-trip behavior.
+- `cmd/root.go:30-42` loads `.spektacular/config.yaml`, returning defaults when the file is absent and errors when it is invalid.
+- `internal/project/init.go:38-44` writes default config only if it does not exist. Updating `NewDefault()` updates newly initialized projects.
+- `cmd/init.go:36-44` loads, mutates, and writes config during `init`, so new fields must survive re-init paths.
+- `internal/store/store.go:48-55` rejects paths that escape the store root; identifier validation should still reject unsafe characters before path construction.
+- `internal/store/store.go:112-119` checks path existence, which is enough for timestamp, counter, and explicit-id collision detection.
+- `internal/steps/spec/steps_test.go:112-122` verifies that the spec `new()` step writes a scaffold at `SpecFilePath(name)`.
+- `cmd/implement_test.go:38-51` shows the command-test pattern for resetting `rootCmd` output, error, and args between invocations.
+- `templates/skills/workflows/spek-new/SKILL.md:8-31` says the workflow writes `.spektacular/specs/<name>.md`; this needs to change because the returned `spec_name` can now include a generated or supplied prefix.
+- `.agents/skills/spek-new/SKILL.md:8-31` is tracked in this repository and currently has the same stale assumption as the template, so it should be updated directly as part of this plan.
+- `README.md:130-145` has a config section that is already stale relative to the current config struct, but it is the user-facing place to document the new spec id method.
+
+## Per-Phase Technical Notes
+
+### Phase 1.1: Configurable ID Methods
+
+- `internal/config/config.go:13-23` - add a new nested spec config type with `id_method` and `counter` YAML fields, then add that field to `Config`.
+- `internal/config/config.go:25-33` - set `NewDefault().Spec.IDMethod` to `timestamp` and `NewDefault().Spec.Counter` to `0`.
+- `internal/config/config.go:35-49` - no loader rewrite is expected; because loading unmarshals into defaults, existing config files should inherit `timestamp` when `spec.id_method` is omitted. Add tests to prove this rather than changing the loader shape.
+- `internal/config/config_test.go:11-16` - extend default assertions to include `cfg.Spec.IDMethod == "timestamp"`.
+- `internal/config/config_test.go:18-30` - add a test loading YAML with only `command` to prove missing `spec` config defaults to timestamp.
+- `internal/config/config_test.go:37-49` - extend round-trip assertions to include `Spec.IDMethod` and `Spec.Counter`.
+- `internal/project/init.go:38-44` - no direct edit should be needed beyond the config default, but verify the generated config file includes `spec.id_method`.
+- `cmd/init.go:36-44` and `cmd/init_test.go:147-168` - verify re-init with a config file that lacks `spec` still writes a valid config and preserves custom command behavior.
+
+**Complexity**: Low
+**Token estimate**: ~6k
+**Agent strategy**: Single agent, sequential execution.
+
+### Phase 1.2: Identifier Resolution Rules
+
+- `internal/steps/spec/steps.go:11-14` - keep `SpecFilePath(name)` unchanged and treat `name` as already canonical.
+- `internal/steps/spec/` - create a new resolver source file in the spec steps package so `cmd/spec.go` can call it through the existing spec import. Suggested contract shape:
+
+```go
+request := struct {
+    Name   string
+    ID     string
+    Method string
+    Counter int
+    Store  store.Store
+    Now    func() time.Time
+}{}
+
+result := struct {
+    Name    string
+    Counter int
+}{}
+```
+
+- `internal/steps/spec/` - in the new resolver source file, define method constants for `timestamp`, `counter`, and `external`; treat an empty method as timestamp.
+- `internal/steps/spec/` - add a normalization/validation helper shared by requested names and explicit IDs. It must reject empty raw values, leading or trailing whitespace (`raw != strings.TrimSpace(raw)`), path separators, control characters, and values that normalize to empty. It must lower-case ASCII input, preserve alphanumeric characters and underscores, and replace accepted separator/special characters such as `.`, `@`, `-`, and internal whitespace runs with a single `-`.
+- `internal/steps/spec/` - compose final names with a hyphen separator: `<prefix>-<name>`.
+- `internal/steps/spec/` - timestamp mode should use `req.Now().UTC().Format("20060102150405")`; default `Now` to `time.Now` if omitted. Before returning, check whether `SpecFilePath(candidate)` exists; if it does, add one second and retry until the candidate is unused.
+- `internal/steps/spec/` - counter mode should start from `req.Counter + 1`, format as six digits, and check for collisions. If the target exists because the stored counter is stale, keep incrementing until an unused target is found and return that value as the new current counter.
+- `internal/steps/spec/` - explicit id mode should also check the target path and fail on collision rather than overwrite an existing spec.
+- `internal/store/store.go:112-119` - use `Exists(SpecFilePath(candidate))` for timestamp, counter, and explicit-id collision detection.
+- `internal/steps/spec/` - create a new resolver test file with deterministic tests for default timestamp, timestamp collision bumping, explicit timestamp method, counter from configured value, stale counter collision bumping, explicit id override with normalization, external missing id, external with normalized id, unknown method, leading/trailing whitespace rejection, slash/control-character rejection, and nil store in generated modes.
+
+**Complexity**: Medium
+**Token estimate**: ~12k
+**Agent strategy**: Single agent, sequential execution; tests should be written alongside the resolver because the behavior is compact and state-free.
+
+### Phase 2.1: Native Spec Creation Wiring
+
+- `cmd/spec.go:21-39` - `schemaProp` already supports type, enum, pattern, and maxLength. Reuse it to describe optional `id` in the `spec new --schema` input.
+- `cmd/spec.go:136-148` - update schema properties to include `id` with a filename-safe pattern and max length. Keep `Required` as only `name`.
+- `cmd/spec.go:151-159` - extend the anonymous input struct with `ID string `json:"id"``.
+- `cmd/spec.go:163-165` - replace the direct requested-name regex check with the shared normalization/validation helper so names like `Team.Alpha` normalize to `team-alpha` while names with leading/trailing whitespace fail.
+- `cmd/root.go:30-42` - add a helper that returns the config path, or otherwise expose the path to `runSpecNew`, because counter mode must write the updated `spec.counter` value back to `.spektacular/config.yaml`.
+- `cmd/spec.go:167-186` - create the store before workflow creation, resolve the canonical name with config and input id, persist any counter update when not dry-run, then remove state only after resolution and counter persistence succeed.
+- `cmd/spec.go:183-187` - pass the same store instance to `workflow.New` and set workflow data `name` to the resolved canonical name, not the requested suffix.
+- `cmd/spec.go:193-195` - keep `output.WriteError` behavior for workflow errors. Resolver/config validation errors can return directly, matching current validation style.
+- `internal/steps/spec/steps.go:71-77` - no method branching should be added here. The step writes the scaffold using the canonical name it receives.
+- `internal/steps/spec/strategy.go:14-18` - no direct change expected; verify returned `spec_path` and `spec_name` reflect the canonical name.
+- `cmd/spec.go:176-180` - preserve dry-run behavior. Dry-run should resolve and report the canonical name but avoid removing state, writing a spec file, or updating the persisted counter.
+
+**Complexity**: Medium
+**Token estimate**: ~10k
+**Agent strategy**: Single agent, sequential execution because command state ordering and resolver use are tightly coupled.
+
+### Phase 2.2: Public Command Contract Coverage
+
+- `cmd/` - create a new spec command test file rather than overloading `internal/steps/spec` tests. Mirror the `setupImplementCmd` pattern from `cmd/implement_test.go:38-51`.
+- `cmd/` - add helper setup that creates `.spektacular/`, writes optional config YAML, executes `rootCmd`, and decodes JSON output.
+- `cmd/` - test default creation creates exactly one spec file whose basename matches `^\d{14}-billing-export\.md$`, returns `step == "overview"`, and returns matching normalized `spec_name` and `spec_path`.
+- `cmd/` - test timestamp collision by pre-creating the first timestamp target and asserting creation bumps to the next second.
+- `cmd/` - test counter mode with config `spec.id_method: counter` and `spec.counter: 7` produces `000008-billing-export.md` and persists `spec.counter: 8`.
+- `cmd/` - test stale counter collision by pre-creating `000008-billing-export.md` and asserting the command creates `000009-billing-export.md` and persists `9`.
+- `cmd/` - test explicit `id` input like `EXT.User@123` creates `ext-user-123-billing-export.md` even when config is timestamp or counter.
+- `cmd/` - test external mode without id returns an error and leaves both the specs directory and shared state file absent or unchanged.
+- `cmd/` - test external mode with id succeeds.
+- `cmd/` - test `spec new --schema` contains `"id"` and keeps `"name"` required.
+- `cmd/` - test unsafe and untrimmed name/id values fail before file creation.
+- `internal/steps/spec/steps_test.go:112-122` - keep the existing scaffold test as-is or update only if helper names move; it should continue to prove `new()` writes `SpecFilePath(name)`.
+
+**Complexity**: Medium
+**Token estimate**: ~14k
+**Agent strategy**: Single agent. Command tests share global `rootCmd`; keep them sequential and isolated with cleanup.
+
+### Phase 3.1: Generated Guidance And Documentation
+
+- `templates/skills/workflows/spek-new/SKILL.md:8` - update wording so it says the workflow produces the spec file returned by `spec_path`, not always `.spektacular/specs/<name>.md`.
+- `templates/skills/workflows/spek-new/SKILL.md:25-31` - add a short note that external callers may pass `id` in the JSON payload and that agents should use the returned `spec_name` for later plan workflows.
+- `.agents/skills/spek-new/SKILL.md:8-31` - update the tracked local skill alongside the template so Codex in this repository sees the new behavior immediately.
+- `README.md:130-145` - replace or augment the stale config example with a minimal current config example that includes `spec.id_method: timestamp` and documents valid values `timestamp`, `counter`, and `external`.
+- `README.md` near spec creation usage - document `spec new --data '{"name":"billing-export","id":"EXT-123"}'` as the external-id override example if the surrounding command reference exists.
+- `CHANGELOG.md` - if implementation conventions require changelog updates for user-facing CLI behavior, add a concise entry describing timestamp default prefixes and optional external IDs.
+
+**Complexity**: Low
+**Token estimate**: ~7k
+**Agent strategy**: Single agent, sequential execution.
+
+### Phase 3.2: Final Regression Pass
+
+- `internal/config/config_test.go` - run the config package tests after config changes.
+- `internal/steps/spec/` package tests and `internal/steps/spec/steps_test.go` - run the spec package tests after resolver and workflow checks.
+- `cmd/` package tests - run command tests after command wiring and schema changes.
+- `cmd/init_test.go` and `internal/project/init_test.go` - run init tests after config defaults and docs/guidance changes.
+- Full repository test suite - run once after focused tests pass.
+- Manual smoke path - from a temp project or with dry-run where appropriate, verify a spec creation returns a prefixed `spec_name` and that the next plan workflow can target that returned name.
+
+**Complexity**: Low
+**Token estimate**: ~5k
+**Agent strategy**: Single agent. Parallel test execution is handled by Go; no multi-agent split is needed.
+
+## Testing Strategy
+
+Use three layers of coverage. First, pure resolver tests should prove naming rules with no Cobra or workflow involvement. Second, command tests should prove external behavior through JSON input, schema output, filesystem writes, and state side effects. Third, existing workflow, config, init, and store tests should serve as regression coverage so the feature does not accidentally change unrelated workflow behavior.
+
+The most important cases are timestamp default behavior, timestamp collision bumping, explicit id normalization, counter incrementing and persistence, stale counter collision handling, external mode requiring id, unsafe or untrimmed input rejection, existing config compatibility, and schema discoverability.
+
+## Project References
+
+- Specification: `.spektacular/specs/spec-id-prefix-method.md`
+- Plan namespace from workflow: `spec-id-prefix-method`
+- Derived feature slug from existing plans: `0020-spec-id-prefix-method`
+- Metadata: created `2026-05-08T17:49:29Z`, commit `a3108b2`, branch `main`, repository `https://github.com/gregoryhunt/spektacular.git`
+
+## Token Management Strategy
+
+| Tier | Token Budget | Agent Strategy |
+|------|-------------|----------------|
+| Low | ~10k | Single agent, sequential |
+| Medium | ~25k | Single agent with focused file reads; optional split only between docs and tests |
+| High | ~50k+ | Not expected for this feature |
+
+## Migration Notes
+
+Existing config files remain valid because the new fields are optional and default to timestamp plus counter zero. Existing specification files are not renamed. The default behavior for new spec creation changes from unprefixed names to timestamp-prefixed names, and accepted names/ids are normalized, so callers that previously assumed the requested name was the final filename must use the returned `spec_name` or `spec_path`.
+
+## Performance Considerations
+
+Timestamp and explicit-id modes are constant-time unless they encounter a collision, in which case they perform repeated existence checks until an unused target is found or the explicit-id collision fails. Counter mode uses the persisted counter and only performs existence checks while avoiding stale-counter collisions, so it no longer needs to scan all spec filenames. If a project accumulates enough collisions to make repeated checks expensive, that indicates the counter or timestamp source is stale and should be investigated separately.

--- a/.spektacular/plans/spec-id-prefix-method/plan.md
+++ b/.spektacular/plans/spec-id-prefix-method/plan.md
@@ -1,0 +1,281 @@
+# Plan: spec-id-prefix-method
+
+<!-- Metadata -->
+<!-- Created: 2026-05-08T17:49:29Z -->
+<!-- Commit: a3108b2 -->
+<!-- Branch: main -->
+<!-- Repository: https://github.com/gregoryhunt/spektacular.git -->
+<!-- Feature Slug: 0020-spec-id-prefix-method -->
+
+## Overview
+
+Specification creation will produce prefixed, chronologically sortable names by default while still allowing teams to choose counter-based names or accept identifiers from external systems. This makes new specs easier to organize and safer to automate without changing the authoring workflow users already follow.
+
+## Architecture & Design Decisions
+
+The chosen design resolves the final specification name before the spec workflow is created. The creation request still starts with a human-readable name, but `spec new` converts that request into the canonical workflow name by applying an explicit identifier, a timestamp prefix, or the next counter prefix. The rest of the workflow continues to operate on one name, so the returned `spec_name`, saved state, status output, scaffold title, and file path all agree.
+
+Identifier generation is owned by a small resolver with three supported methods: `timestamp`, `counter`, and `external`. The default is `timestamp`, explicit `id` input overrides generated methods, and `external` mode requires that the caller provide `id`. Timestamp prefixes use UTC and lexicographic formatting with second-bump collision handling; counter prefixes use a zero-padded numeric prefix backed by a persisted project counter.
+
+Configuration stays additive through a nested spec config block, so existing config files remain valid and new projects expose the default method and counter value. The command schema is expanded to document optional `id` input for agents and external callers. Rejected options are captured in [research.md#alternatives-considered-and-rejected](./research.md#alternatives-considered-and-rejected), especially the alternatives of doing this in skills or mutating only the file path inside the workflow.
+
+## Component Breakdown
+
+- **Spec identifier resolver** owns method validation, normalization, prefix generation, collision checks, explicit identifier validation, and final canonical name composition. It is the only component that needs to know how timestamp, counter, and external identifier modes differ.
+- **Project configuration** owns the optional default method and current counter value for spec identifiers. It provides defaults when fields are omitted and persists counter progress for counter mode.
+- **Spec creation command adapter** owns JSON input parsing, schema reporting, loading configuration, invoking the resolver, and starting the workflow with the canonical name.
+- **Existing spec workflow** continues to own scaffold rendering, step instructions, state persistence, and final spec file writes. It receives the canonical name and does not branch on identifier method.
+- **Guidance and tests** keep installed skills, docs, and regression coverage aligned with the new creation contract so agents know to trust the returned spec path and spec name.
+
+## Data Structures & Interfaces
+
+The config contract gains a nested spec block and the creation input gains an optional `id` value:
+
+```go
+type Config struct {
+    Command string      `yaml:"command"`
+    Agent   string      `yaml:"agent"`
+    Debug   DebugConfig `yaml:"debug"`
+    Spec    struct {
+        IDMethod string `yaml:"id_method"`
+        Counter  int    `yaml:"counter"`
+    } `yaml:"spec"`
+}
+```
+
+The resolver contract accepts the requested name, optional id, configured method, store access for counter mode, and a clock for timestamp mode. It returns the canonical workflow name or a validation error:
+
+```go
+request := struct {
+    Name   string
+    ID     string
+    Method string
+    Counter int
+    Store  store.Store
+    Now    func() time.Time
+}{}
+
+result := struct {
+    Name    string
+    Counter int
+}{}
+```
+
+Supported method values are `timestamp`, `counter`, and `external`. An empty method is equivalent to `timestamp`. Names and identifiers are normalized by lowercasing and replacing accepted separator characters with `-`; leading or trailing whitespace is a validation error, not something the system trims.
+
+## Implementation Detail
+
+The implementation introduces one focused naming boundary before workflow state is created. Command parsing validates the requested suffix name, loads configuration, creates the project store, resolves the canonical spec name, and only then removes or writes workflow state. This ordering ensures configuration errors, invalid identifiers, or missing external identifiers fail without creating a spec file or clobbering active state.
+
+The resolver treats explicit `id` input as a universal override after normalization. Generated methods only run when no id is provided; `external` mode is the opposite contract and errors unless id is provided. Input validation rejects empty values, leading or trailing whitespace, path separators, and control characters, then normalizes accepted values by lowercasing and replacing separators such as `.`, `@`, and internal whitespace with `-`.
+
+Counter generation reads the current project counter from config, increments it, formats it with six digits, and persists the new current value as part of successful counter allocation. Timestamp generation uses UTC seconds in `YYYYMMDDHHMMSS` form so alphabetical order matches creation order; if a timestamp-created filename already exists, the resolver adds one second and checks again until it finds an unused filename. Existing file write behavior remains owned by the workflow and store, but the command must not allow generated or explicit names to overwrite an existing spec.
+
+## Dependencies
+
+- **Cobra command handling** provides the existing subcommand, flag, and schema surfaces; it needs a narrow input/schema update for optional id.
+- **YAML config loading** provides default-backed config parsing; it needs one nested config block and tests for omission/round-trip behavior.
+- **Project file store** provides path traversal protection and existence checks; it is reused for collision detection without API changes.
+- **Spec workflow steps** provide scaffold writing and status/path output; they should continue to receive one canonical name.
+- **Embedded skill templates and README docs** provide user and agent guidance; they need wording updates so generated names and optional ids are visible.
+- **Standard library time and parsing utilities** are sufficient for timestamp formatting, counter parsing, and validation; no new third-party dependency is required.
+
+## Testing Approach
+
+Testing concentrates on the resolver and command boundary because those are the places where behavior changes. Resolver unit tests should use deterministic clocks and temp stores to prove method defaults, timestamp formatting, timestamp collision bumping, counter incrementing from config, explicit id normalization, external mode requirements, and invalid identifiers.
+
+Command-level tests should exercise `spec new` as an external caller sees it: JSON input, schema output, file creation, returned path/name, dry-run behavior, and failure without side effects. Config tests should prove old config files remain valid and new defaults round-trip.
+
+Existing workflow tests remain valuable regression coverage. They should continue to pass with canonical names because the workflow should not need to understand how those names were chosen.
+
+## Milestones & Phases
+
+### Milestone 1: Identifier Rules Are Defined
+
+**What changes**: The project gains a clear, testable contract for how spec identifiers are configured, generated, and validated. This milestone does not change the user-facing creation flow yet; it creates the safe foundation that later phases wire into creation.
+
+#### - [x] Phase 1.1: Configurable ID Methods
+
+Add the optional spec identifier method and current counter value to configuration with timestamp and zero as defaults. Existing config files continue to load without edits, while newly written configs expose the default method and counter clearly. This phase establishes the persistent project preference and counter state before any creation behavior depends on them.
+
+*Technical detail:* [context.md#phase-11-configurable-id-methods](./context.md#phase-11-configurable-id-methods)
+
+**Acceptance criteria**:
+
+- [x] Projects without a spec identifier setting still load with timestamp behavior selected.
+- [x] New or round-tripped config output includes the spec identifier method and current counter without losing existing command, agent, or debug settings.
+- [x] Invalid or unknown method values are rejected when spec creation tries to use them.
+
+#### - [x] Phase 1.2: Identifier Resolution Rules
+
+Add the resolver that turns a requested spec name into the canonical spec name. It normalizes accepted names and ids without trimming, covers timestamp, counter, and external identifier methods, treats a passed id as an override for generated methods, and returns any updated counter value. This phase makes the naming behavior deterministic and isolated before command wiring.
+
+*Technical detail:* [context.md#phase-12-identifier-resolution-rules](./context.md#phase-12-identifier-resolution-rules)
+
+**Acceptance criteria**:
+
+- [x] Timestamp resolution produces a sortable timestamp prefix followed by the requested name.
+- [x] Timestamp resolution bumps by seconds when the initial timestamp target already exists.
+- [x] Counter resolution uses the next persisted counter value and returns the updated current counter.
+- [x] Passed identifiers are normalized, accepted for generated methods, and required for external mode.
+- [x] Unsafe or untrimmed name and identifier values are rejected before any file path is built.
+
+### Milestone 2: Spec Creation Uses Canonical Names
+
+**What changes**: Users and external systems get the new naming behavior through the native spec creation command. The returned spec path, active workflow state, and created file all use the same canonical name.
+
+#### - [x] Phase 2.1: Native Spec Creation Wiring
+
+Wire the resolver into spec creation before workflow state is created. The command accepts optional id input, applies the configured method, persists counter changes when counter mode allocates a value, and starts the existing workflow with the resolved canonical name. Failure cases stop before any spec file or workflow state is written.
+
+*Technical detail:* [context.md#phase-21-native-spec-creation-wiring](./context.md#phase-21-native-spec-creation-wiring)
+
+**Acceptance criteria**:
+
+- [x] Creating a spec without id or config uses a timestamp-prefixed filename.
+- [x] Creating a spec with id uses the normalized id as the prefix regardless of generated method configuration.
+- [x] External mode without id fails clearly and leaves no new spec file behind.
+- [x] Counter mode advances the persisted current counter when creation succeeds.
+- [x] Dry-run creation reports the same canonical name shape without writing files.
+
+#### - [x] Phase 2.2: Public Command Contract Coverage
+
+Add command-level coverage for the behavior external callers rely on. These tests verify the JSON input contract, schema visibility, returned metadata, and filesystem outcomes. This phase catches regressions that pure resolver tests cannot see.
+
+*Technical detail:* [context.md#phase-22-public-command-contract-coverage](./context.md#phase-22-public-command-contract-coverage)
+
+**Acceptance criteria**:
+
+- [x] The creation schema documents both `name` and optional `id`.
+- [x] Timestamp, timestamp collision, counter, explicit id normalization, and external-mode cases are observable through command output.
+- [x] Validation failures do not leave behind a created spec or new workflow state.
+
+### Milestone 3: Guidance And Regression Safety Are Updated
+
+**What changes**: Agents, users, and future maintainers can see and trust the new naming behavior. Documentation and generated guidance explain that callers should use the spec name and path returned by the command.
+
+#### - [x] Phase 3.1: Generated Guidance And Documentation
+
+Update the generated and tracked spec workflow guidance plus user-facing docs to describe prefixed names, normalized optional id input, and the config method. This keeps installed agent instructions aligned with the binary-owned behavior without requiring wrapper logic.
+
+*Technical detail:* [context.md#phase-31-generated-guidance-and-documentation](./context.md#phase-31-generated-guidance-and-documentation)
+
+**Acceptance criteria**:
+
+- [x] Generated spec workflow guidance no longer assumes the requested name is always the final filename.
+- [x] The tracked local `spek-new` skill is updated alongside the template so repository agents see the new behavior immediately.
+- [x] User-facing documentation shows the config method values and optional id input.
+- [x] Documentation tells callers to use returned spec metadata for follow-up workflows.
+
+#### - [x] Phase 3.2: Final Regression Pass
+
+Run the focused package tests and the full test suite after all changes are integrated. This phase verifies the new behavior and checks that existing spec, plan, init, config, and store workflows still operate normally.
+
+*Technical detail:* [context.md#phase-32-final-regression-pass](./context.md#phase-32-final-regression-pass)
+
+**Acceptance criteria**:
+
+- [x] All resolver, config, command, and existing workflow tests pass.
+- [x] A manual spec creation produces a prefixed spec path and a usable next workflow state using the returned normalized `spec_name`.
+- [x] No existing plan or implementation artifact naming behavior changes.
+
+## Open Questions
+
+None.
+
+## Out of Scope
+
+- Renaming or migrating existing specification files is out of scope.
+- Building a direct integration with any specific external system is out of scope.
+- Changing the contents or step order of the specification authoring workflow is out of scope.
+- Applying the same identifier method to plans or implementation artifacts is out of scope.
+- Reformatting legacy unpadded or underscore-separated numeric spec filenames is out of scope.
+- Guaranteeing gapless counter values is out of scope; failed filesystem writes after counter allocation may leave skipped numbers.
+
+## Changelog
+
+### FINAL SUMMARY
+
+Implemented native spec identifier prefixes across configuration, resolver logic, `spec new`, command tests, generated guidance, and user-facing docs. New spec creation now defaults to timestamp prefixes, supports persisted counter prefixes, accepts optional external ids, and requires ids for external mode while returning canonical `spec_name` and `spec_path` for follow-up workflows.
+
+**Total phases**: 6/6 completed
+
+**Notable deviations from the plan**: None
+
+### 2026-05-09 - Phase 1.1: Configurable ID Methods
+
+**What was done**: Added `spec.id_method` and `spec.counter` to project configuration with `timestamp` and `0` defaults. Config loading now validates the configured spec ID method, and init/spec command tests cover old config compatibility, round-tripped output, generated config defaults, and `spec new` rejection for unsupported methods.
+
+**Deviations**: None
+
+**Files changed**:
+- `internal/config/config.go`
+- `internal/config/config_test.go`
+- `internal/project/init_test.go`
+- `cmd/init_test.go`
+- `cmd/spec_test.go`
+
+**Discoveries**: Method validation belongs at config load time for this phase because every command that starts a workflow already loads config first; later resolver wiring can reuse the exported config method constants instead of duplicating strings.
+
+### 2026-05-09 - Phase 1.2: Identifier Resolution Rules
+
+**What was done**: Added a spec identifier resolver that normalizes names and optional ids, supports timestamp, counter, and external modes, checks collisions through the project store, and bumps timestamp seconds or counter values until generated names are unused. The resolver returns the canonical spec name plus the current counter value that command wiring can persist later.
+
+**Deviations**: None
+
+**Files changed**:
+- `internal/steps/spec/identifier.go`
+- `internal/steps/spec/identifier_test.go`
+
+**Discoveries**: Explicit id overrides intentionally leave the returned counter unchanged, so Phase 2.1 can persist `spec.counter` only when counter allocation actually advances it.
+
+### 2026-05-09 - Phase 2.1: Native Spec Creation Wiring
+
+**What was done**: Wired `spec new` through the identifier resolver so new specs use canonical timestamp, counter, or external-id names before workflow state is created. Counter mode now persists the advanced `spec.counter` on successful non-dry-run creation, while dry-run resolves and reports the same canonical name without writing specs, state, or counter updates.
+
+**Deviations**: None
+
+**Files changed**:
+- `cmd/root.go`
+- `cmd/spec.go`
+- `cmd/spec_test.go`
+- `internal/steps/spec/identifier.go`
+
+**Discoveries**: Auxiliary `--stdin` and `--file` workflow data must not be allowed to override the resolved `name`; the command now applies extra workflow data first and then restores the canonical name before starting the workflow.
+
+### 2026-05-09 - Phase 2.2: Public Command Contract Coverage
+
+**What was done**: Expanded command-level tests to cover `spec new --schema`, timestamp defaults, timestamp collision bumping, counter and stale-counter behavior, explicit id normalization, external mode success and failure, dry-run output, and validation failures without spec/state side effects. Added a small injectable clock for `spec new` so timestamp collision behavior is deterministic in tests.
+
+**Deviations**: None
+
+**Files changed**:
+- `cmd/spec.go`
+- `cmd/spec_test.go`
+
+**Discoveries**: Cobra flag values can persist between same-process command tests, so the spec command test helper now resets `schema`, `dry-run`, and input flags around each invocation.
+
+### 2026-05-09 - Phase 3.1: Generated Guidance And Documentation
+
+**What was done**: Updated generated and tracked `spek-new` guidance so agents use returned `spec_name` and `spec_path` instead of assuming the requested name is final. README now documents optional external ids, returned metadata usage, and the `spec.id_method` values; the repo changelog includes the user-facing behavior change.
+
+**Deviations**: None
+
+**Files changed**:
+- `templates/skills/workflows/spek-new/SKILL.md`
+- `.agents/skills/spek-new/SKILL.md`
+- `README.md`
+- `CHANGELOG.md`
+
+**Discoveries**: The README command examples were still using older shorthand commands, so the usage section was updated to the current workflow command shape while documenting the new identifier behavior.
+
+### 2026-05-09 - Phase 3.2: Final Regression Pass
+
+**What was done**: Ran focused regression packages, the full Go test suite, and a manual smoke path in a temp project. The smoke created a timestamp-prefixed spec and then started `plan new` with the returned normalized `spec_name`.
+
+**Deviations**: None
+
+**Files changed**:
+- `.spektacular/plans/spec-id-prefix-method/plan.md`
+
+**Discoveries**: `go run` cannot target this module from outside the module directory in the local environment, so the manual smoke used a temporary built binary instead.

--- a/.spektacular/plans/spec-id-prefix-method/research.md
+++ b/.spektacular/plans/spec-id-prefix-method/research.md
@@ -1,0 +1,96 @@
+# Research: spec-id-prefix-method
+
+## Alternatives considered and rejected
+
+### Option A: Implement prefixes only in installed skills or command wrappers
+
+This would update `spek-new` instructions or agent-specific wrappers to prepend timestamps, counters, or external ids before invoking the binary.
+
+**Rejected**: the specification requires native binary behavior, and wrappers are not the canonical execution surface. Current generated skill guidance invokes the binary with a JSON payload (`templates/skills/workflows/spek-new/SKILL.md:25-31`), while init installs multiple agent surfaces (`cmd/init.go:47-50`). Putting naming rules in wrappers would duplicate behavior across agents and leave external callers of the binary without the feature.
+
+### Option B: Prefix only the file path inside the spec workflow step
+
+This would keep workflow data `name` as the user-supplied name and make the spec `new()` step write a different prefixed path.
+
+**Rejected**: the current workflow uses the same data name for path construction and returned metadata. `SpecFilePath(name)` builds `specs/<name>.md` (`internal/steps/spec/steps.go:11-14`), `new()` writes that path (`internal/steps/spec/steps.go:71-77`), strategy output reports `spec_name` and `spec_path` from the same name (`internal/steps/spec/strategy.go:14-18`), and status reconstructs the path from workflow data (`cmd/spec.go:274-286`). Splitting path identity from workflow identity would make follow-up workflows and status output ambiguous.
+
+### Option C: Add separate command flags for identifier behavior
+
+This would add flags such as `--id` or `--method` beside the existing JSON payload rather than extending `--data`.
+
+**Rejected**: the current command contract is JSON input plus schema introspection. `spec new` reads a JSON object from `--data` (`cmd/spec.go:151-162`) and reports its JSON schema (`cmd/spec.go:136-148`). The local CLI architecture note recommends raw JSON payloads, runtime schema introspection, and strong input validation for agent-facing commands (`.spektacular/knowledge/architecture/cli-design-for-ai-agents.md:11-29`). Adding parallel flags would make the command harder for agents and external systems to discover and validate.
+
+### Option D: Store the counter in workflow state
+
+This would track the current counter in the existing workflow state file.
+
+**Rejected**: the current project uses a shared workflow state file that is truncated on each workflow start (`cmd/spec.go:176-180`, `.spektacular/plans/15_implementation/context.md:11-13`). Putting a project-level counter there risks losing the counter whenever another workflow starts. The chosen persistent location is config, where the identifier method already lives.
+
+### Option E: Derive counter values only from existing filenames
+
+This would scan existing spec filenames and select the next number without storing counter state.
+
+**Rejected**: after timestamp prefixes become the default, filename scanning risks confusing timestamp prefixes with counter prefixes unless the parser becomes more complex. It also makes counter behavior depend on historical files rather than the user's configured current counter. A persisted `spec.counter` value gives counter mode an explicit source of truth while still allowing collision checks to avoid overwrites.
+
+## Chosen approach — evidence
+
+- Resolving the canonical name before workflow creation matches existing workflow design because all downstream path and status output already flows from the workflow data `name` (`cmd/spec.go:183-187`, `cmd/spec.go:274-286`, `internal/steps/spec/strategy.go:14-18`).
+- The spec workflow `new()` step already writes a scaffold using `SpecFilePath(name)` (`internal/steps/spec/steps.go:63-80`), so passing a canonical name lets this behavior remain simple.
+- Config loading already unmarshals into `NewDefault()` (`internal/config/config.go:35-49`), which supports additive optional config fields without breaking older config files.
+- Project init writes the default config from `config.NewDefault()` (`internal/project/init.go:38-44`), so adding the default method and counter there also makes them visible to new projects.
+- The file store already rejects path traversal (`internal/store/store.go:48-55`) and can check candidate paths for collision through `Exists` (`internal/store/store.go:112-119`).
+- The command schema types already support pattern, enum, and max length fields (`cmd/spec.go:21-39`), enough to expose the optional id input without schema machinery changes.
+- `plan new` and `implement new` validate workflow names with the shared `nameRegexp` shape (`cmd/plan.go:89-97`, `cmd/implement.go:93-100`), so spec-created names must be normalized into that compatible shape rather than preserving uppercase or special characters.
+
+## Files examined
+
+- `.spektacular/specs/spec-id-prefix-method.md:1` - source specification for timestamp default, counter mode, explicit id override, config method, and non-goals.
+- `.spektacular/knowledge/architecture/cli-design-for-ai-agents.md:11` - local architecture note favoring JSON payloads and runtime schema introspection for agent-facing CLIs.
+- `.spektacular/knowledge/conventions.md:11` - local conventions call for tests on new functionality and README updates for user-facing changes.
+- `.spektacular/plans/13_agent-cli-improvements/plan.md:34` - prior plan established schema introspection and JSON `--data` as command design.
+- `.spektacular/plans/14_spektacular-store/plan.md:220` - prior plan describes store-backed workflow writes and validates spec file creation through the store.
+- `.spektacular/plans/15_implementation/context.md:11` - prior context confirms spec and plan workflows share `.spektacular/state.json`.
+- `cmd/spec.go:19` - existing requested-name regex is lowercase alphanumeric, hyphen, and underscore.
+- `cmd/spec.go:136` - `runSpecNew` owns schema, input parsing, config loading, state removal, workflow creation, and initial workflow data.
+- `cmd/spec.go:259` - status output derives spec path from the workflow data name.
+- `cmd/plan.go:89` - plan creation currently accepts only lowercase workflow names, so spec names returned from this feature must be normalized for follow-up workflows.
+- `cmd/implement.go:93` - implement creation uses the same workflow-name validation shape as plan creation.
+- `cmd/root.go:30` - config loading returns defaults when `.spektacular/config.yaml` is absent.
+- `cmd/init.go:36` - init loads, mutates, and writes config, so new config fields must survive re-init.
+- `cmd/implement_test.go:38` - command tests reset root command state with a helper pattern that can be reused for spec command tests.
+- `internal/config/config.go:18` - top-level config currently has `Command`, `Agent`, and `Debug`.
+- `internal/config/config.go:25` - defaults are centralized in `NewDefault()`.
+- `internal/config/config_test.go:11` - existing config tests cover default and round-trip behavior.
+- `internal/project/init.go:38` - default config writing happens through `config.NewDefault()`.
+- `internal/project/init_test.go:33` - project init tests confirm config file creation.
+- `internal/steps/spec/steps.go:11` - `SpecFilePath` is the path helper for spec files.
+- `internal/steps/spec/steps.go:63` - spec `new()` writes the scaffold and should continue to receive one canonical name.
+- `internal/steps/spec/steps_test.go:112` - existing test asserts scaffold writing through `SpecFilePath`.
+- `internal/steps/spec/strategy.go:14` - path strategy reports spec path and name from the workflow instance name.
+- `internal/store/store.go:48` - store path resolution rejects paths that escape the root.
+- `internal/store/store.go:112` - store existence checks support collision detection for timestamp, counter, and explicit-id targets.
+- `templates/skills/workflows/spek-new/SKILL.md:8` - generated spec skill currently assumes the requested name is the final filename.
+- `README.md:130` - README has the user-facing config section to update for `spec.id_method`.
+
+## External references
+
+None fetched during this planning pass. The local architecture note at `.spektacular/knowledge/architecture/cli-design-for-ai-agents.md` cites an external CLI design article and was used only for local design principles.
+
+## Prior plans / specs consulted
+
+- `.spektacular/specs/spec-id-prefix-method.md` - defines the required behavior and explicitly excludes existing spec migration, external-system integrations, workflow content changes, and plan/implementation artifact naming.
+- `.spektacular/plans/13_agent-cli-improvements/plan.md` - confirms the project direction for JSON `--data`, schema introspection, dry-run behavior, and agent-facing validation.
+- `.spektacular/plans/14_spektacular-store/plan.md` - confirms spec creation is store-backed and that path traversal protection belongs in the store layer while command/spec validation remains useful.
+- `.spektacular/plans/15_implementation/context.md` - confirms current workflow state is shared and should not be split or migrated for this feature.
+
+## Open assumptions
+
+None. The reviewed gaps have been resolved in the plan: externally supplied-id mode is `external`, timestamp collisions bump by whole seconds, counter mode uses persisted config state, accepted names and ids are normalized without trimming, and tracked/generated skill guidance is updated.
+
+## Rehydration cues
+
+- Re-read `.spektacular/specs/spec-id-prefix-method.md` for the feature contract.
+- Re-read `cmd/spec.go`, `internal/config/config.go`, `internal/steps/spec/steps.go`, `internal/steps/spec/strategy.go`, and `internal/store/store.go` before implementation.
+- Use `rg -n "spec new|SpecFilePath|nameRegexp|config.yaml|id_method|counter|schema" cmd internal templates README.md .spektacular` to rebuild the local map.
+- Use `go run . spec new --schema` after implementation to verify schema visibility.
+- Focus first on resolver tests, then command tests, then full regression.

--- a/.spektacular/specs/spec-id-prefix-method.md
+++ b/.spektacular/specs/spec-id-prefix-method.md
@@ -1,0 +1,149 @@
+# Feature: spec-id-prefix-method
+
+<!--
+  OVERVIEW
+  A concise 2-3 sentence summary of the feature. Answer three questions:
+    1. What is being built?
+    2. What problem does it solve?
+    3. Who benefits and why does it matter?
+  Avoid implementation details — this should be readable by any stakeholder.
+-->
+## Overview
+
+Specification creation should generate stable, migration-style identifiers by default so new specs sort chronologically and avoid ambiguous naming collisions. Teams can choose timestamp-based or counter-based generated prefixes, while external systems can supply their own normalized identifier when they create a spec, making automated integrations predictable without removing manual flexibility.
+
+
+<!--
+  REQUIREMENTS
+  Specific, testable behaviours the feature must deliver.
+  Format: bold title on the checkbox line, detail indented below.
+  Rules:
+    - Use active voice: "Users can...", "The system must..."
+    - Each requirement should be independently verifiable
+    - Focus on WHAT, not HOW — avoid prescribing implementation
+    - Keep each item atomic — one behaviour per line
+-->
+## Requirements
+
+- [ ] **Timestamp prefixes by default**
+      The system must generate timestamp-style prefixes for new specifications when no other identifier method is configured or requested.
+- [ ] **Counter prefixes available**
+      Users can choose counter-style generated prefixes for new specifications.
+- [ ] **External identifiers accepted**
+      Users and external systems can pass an explicit identifier during specification creation, and the system must use the normalized value instead of generating one.
+- [ ] **Input normalization and validation**
+      The system must normalize accepted spec names and identifiers into valid workflow names without silently trimming leading or trailing whitespace.
+- [ ] **Configurable identifier method**
+      Users can set a default identifier method in configuration so future specification creation uses that method unless an explicit identifier is provided.
+- [ ] **Explicit identifiers override method defaults**
+      The system must accept a passed identifier regardless of the configured identifier method.
+- [ ] **Required identifiers for external mode**
+      When configuration selects the externally supplied identifier method, specification creation must require an explicit identifier value.
+- [ ] **Native creation behavior**
+      Identifier selection and validation must be available through the standard specification creation workflow without requiring a separate wrapper or integration script.
+
+
+<!--
+  CONSTRAINTS
+  Hard boundaries the solution must operate within. These are non-negotiable.
+  Examples:
+    - Must integrate with the existing authentication system
+    - Cannot introduce breaking changes to the public API
+    - Must support the current minimum supported runtime versions
+  Leave blank if there are no constraints.
+-->
+## Constraints
+
+- Existing specification creation requests that pass only a name must remain valid and must not require a config change.
+- Existing project config files without an identifier method field must remain valid.
+- Identifier values must not be able to create files outside the specification directory.
+- Generated and externally supplied prefixes must produce valid specification filenames on supported filesystems.
+
+
+<!--
+  ACCEPTANCE CRITERIA
+  The specific, binary conditions that define "done".
+  Format: bold title on the checkbox line, verifiable detail indented below.
+  Each criterion must be:
+    - Independently verifiable (pass/fail, not subjective)
+    - Traceable back to a requirement above
+    - Testable by someone who didn't write the code
+-->
+## Acceptance Criteria
+
+- [ ] **Default timestamp prefix is used**
+      When a user creates a specification with name `billing-export` and no identifier method or identifier value is configured or passed, the created specification filename starts with a sortable timestamp prefix followed by `billing-export`.
+- [ ] **Timestamp prefixes sort chronologically**
+      When two specifications are created at different times with the default method, sorting their filenames alphabetically orders them from older to newer.
+- [ ] **Counter prefix can be selected**
+      When a user selects the counter method and creates a specification named `billing-export`, the created specification filename starts with the next available counter prefix followed by `billing-export`.
+- [ ] **Counter prefixes increment**
+      When two specifications are created with the counter method in the same project, the second filename uses the next stored counter value after the first.
+- [ ] **Passed identifier is normalized as the prefix**
+      When a user creates a specification named `billing-export` and passes identifier `EXT-123`, the created specification filename starts with `ext-123` followed by `billing-export`.
+- [ ] **Passed identifier works with any configured generated method**
+      When the project is configured for timestamp or counter generation and a user passes identifier `EXT-123`, the created filename uses `ext-123` rather than a generated timestamp or counter.
+- [ ] **Special characters are normalized**
+      When a user creates a specification with identifier `Team.Alpha@Roadmap`, the created filename starts with `team-alpha-roadmap` followed by the requested name.
+- [ ] **Whitespace is not silently trimmed**
+      When a user passes a spec name or identifier with leading or trailing whitespace, creation fails with a clear error and no specification file is created.
+- [ ] **Configured method becomes the default**
+      When a project config sets the identifier method to counter and the user creates a specification without passing an identifier value, the created filename uses a counter prefix.
+- [ ] **External method requires an identifier**
+      When a project config selects the externally supplied identifier method and a user creates a specification without passing an identifier value, creation fails with a clear error and no specification file is created.
+- [ ] **External method succeeds with an identifier**
+      When a project config selects the externally supplied identifier method and a user creates a specification with identifier `EXT-123`, creation succeeds and the created filename starts with `ext-123` followed by the requested name.
+- [ ] **Timestamp collisions advance by seconds**
+      When the timestamp method would create a filename that already exists for the requested name, creation uses the next available second-level timestamp prefix instead of overwriting the existing file.
+
+
+<!--
+  TECHNICAL APPROACH
+  High-level technical direction to guide the planning agent. Include:
+    - Key architectural decisions already made
+    - Preferred patterns or technologies if known
+    - Integration points with existing systems
+    - Known risks or areas of uncertainty
+  Leave blank if you want the planner to propose the approach.
+-->
+## Technical Approach
+
+- Implement identifier generation inside the `spektacular spec new` path so installed skills and command wrappers inherit the behavior automatically.
+- Extend spec creation input to accept an optional `id` value. When present, normalize and validate it for filename safety, then use it as the prefix regardless of configured generation method.
+- Add input normalization for spec names and identifiers. Normalization lowercases accepted input and replaces special separators such as `.`, `@`, and internal whitespace with `-`; leading or trailing whitespace must fail rather than being trimmed.
+- Add optional config fields for the spec identifier method and current counter value. Supported methods should be `timestamp`, `counter`, and an externally supplied identifier mode. If the method field is omitted, use `timestamp`.
+- Treat the externally supplied identifier mode as a contract that creation requests must provide `id`; generated modes may still accept `id` as an override.
+- Prefer a timestamp format that sorts lexicographically in creation order, such as `YYYYMMDDHHMMSS`, similar to database migration filenames. If the computed timestamp target already exists, increment the timestamp by one second until an unused target is found.
+- For counter mode, persist the current counter value in project config and increment it for each counter-created spec. Use a stable, zero-padded numeric prefix so alphabetical order matches numeric order.
+- Keep the human-readable requested name as the suffix after the generated or supplied prefix.
+- Update command schemas, config loading/defaults, init output, and tests so the new inputs and config field are visible to agents and external callers.
+
+
+<!--
+  SUCCESS METRICS
+  How you will know the feature is working well after delivery. Be specific:
+    - Quantitative: "p99 latency < 200ms", "error rate < 0.1%"
+    - Behavioural: "users complete the flow without support intervention"
+  Leave blank if not applicable.
+-->
+## Success Metrics
+
+- New specifications created without custom settings are alphabetically sortable by creation time.
+- Projects can switch between timestamp and counter prefixes through configuration without changing installed agent skills.
+- External systems can create specifications whose filenames carry the normalized external identifier, with creation failing clearly when external-id mode is configured but no identifier is supplied.
+
+<!--
+  NON-GOALS
+  Explicitly state what this spec does NOT cover. This is as important as
+  the requirements — it prevents scope creep and sets clear expectations.
+  Examples:
+    - "Mobile support is out of scope (tracked in #456)"
+    - "Internationalisation will be addressed in a follow-up spec"
+  Leave blank if there are no explicit exclusions to call out.
+-->
+## Non-Goals
+
+- Renaming or migrating existing specification files is out of scope.
+- Building a direct integration with any specific external system is out of scope.
+- Changing the contents or step order of the specification authoring workflow is out of scope.
+- Applying the same identifier method to plans or implementation artifacts is out of scope unless a later spec requests it.

--- a/.spektacular/state.json
+++ b/.spektacular/state.json
@@ -1,11 +1,20 @@
 {
-  "current_step": "overview",
+  "current_step": "finished",
   "completed_steps": [
-    "new"
+    "new",
+    "read_plan",
+    "analyze",
+    "implement",
+    "test",
+    "verify",
+    "update_plan",
+    "update_changelog",
+    "update_repo_changelog",
+    "finished"
   ],
-  "created_at": "2026-04-19T17:02:31.870898072Z",
-  "updated_at": "2026-04-19T17:02:31.871201179Z",
+  "created_at": "2026-05-08T21:10:12.019613Z",
+  "updated_at": "2026-05-09T13:29:06.06168Z",
   "data": {
-    "name": "testing"
+    "name": "spec-id-prefix-method"
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## spec-id-prefix-method
+
+Spec creation now uses CLI-owned identifier prefixes. By default, `spec new` creates timestamp-prefixed spec names, accepts an optional `id` for external systems, and can be configured with `spec.id_method: timestamp`, `counter`, or `external`. Callers should use the returned `spec_name` and `spec_path` because requested names and ids are normalized before workflow state and files are created.
+
 ## 19_codex_integration
 
 Spektacular now ships first-class support for OpenAI Codex alongside Claude Code and Bob. `spektacular init codex` installs the three workflow entry points — spec, plan, and implement — as native SKILL.md files, so Codex users can invoke `$spek-new`, `$spek-plan`, and `$spek-implement` out of the box. As part of this release the workflow entry points become the canonical artefact type across every supported agent: slash commands for Claude and Bob are now thin wrappers that simply invoke the matching skill, and workflow instructions live in one place rather than being copied per-agent. Existing Claude and Bob users should re-run `spektacular init <agent>` once to pick up the new layout.

--- a/README.md
+++ b/README.md
@@ -57,20 +57,28 @@ Or download a pre-built binary from the [releases page](https://github.com/nicho
 ### Usage
 
 ```bash
-# 1. Initialize a new project
-spektacular init
+# 1. Initialize a new project for your agent
+spektacular init claude
 
-# 2. Create a spec from template
-spektacular new auth-feature --title "User Authentication"
+# 2. Create a spec from the workflow
+spektacular spec new --data '{"name":"auth-feature"}'
 
-# 3. Edit the spec to add your requirements
-$EDITOR .spektacular/specs/auth-feature.md
+# 3. Edit the spec_path returned by the command to add your requirements
+$EDITOR .spektacular/specs/<returned-spec-name>.md
 
-# 4. Generate an implementation plan
-spektacular plan .spektacular/specs/auth-feature.md
+# 4. Generate an implementation plan using the returned spec_name
+spektacular plan new --data '{"name":"<returned-spec-name>"}'
 ```
 
-The plan command opens the TUI, runs the planning agent, and writes output to `.spektacular/plans/auth-feature/`.
+Spec names are normalized and prefixed by the CLI. Use the returned `spec_name` and `spec_path` for follow-up workflows instead of assuming the requested `name` is the final filename.
+
+External systems can pass their own identifier as the prefix:
+
+```bash
+spektacular spec new --data '{"name":"billing-export","id":"EXT-123"}'
+```
+
+Passing `id` is accepted for timestamp and counter projects and is required when `spec.id_method` is `external`.
 
 ## Spec Format
 
@@ -105,15 +113,15 @@ Login flow completes in under 3 seconds.
 Social login with Apple or Microsoft.
 ```
 
-Create a new spec with `spektacular new <name>` to get this template.
+Create a new spec with `spektacular spec new --data '{"name":"auth-feature"}'` to get this template.
 
 ## Project Structure
 
-Running `spektacular init` creates:
+Running `spektacular init <agent>` creates:
 
 ```
 .spektacular/
-├── config.yaml              # Model routing, complexity thresholds
+├── config.yaml              # CLI command, agent, debug, and spec ID settings
 ├── specs/                   # Your specification files
 ├── plans/                   # Generated plans (plan.md, research.md, context.md)
 └── knowledge/               # Project knowledge base
@@ -127,22 +135,25 @@ The knowledge directory feeds context to the planning agent. Adding architecture
 
 ## Configuration
 
-`.spektacular/config.yaml` controls model selection and complexity thresholds:
+`.spektacular/config.yaml` controls the installed agent command and spec identifier behavior:
 
 ```yaml
-models:
-  default: anthropic/claude-3-5-sonnet-20241022
-  tiers:
-    simple: anthropic/claude-3-5-haiku-20241022    # score 0.0–0.3
-    medium: anthropic/claude-3-5-sonnet-20241022   # score 0.3–0.6
-    complex: anthropic/claude-3-opus-20240229      # score 0.6+
-
-complexity:
-  thresholds:
-    simple: 0.3
-    medium: 0.6
-    complex: 0.8
+command: spektacular
+agent: claude
+debug:
+  enabled: false
+spec:
+  id_method: timestamp
+  counter: 0
 ```
+
+`spec.id_method` controls the prefix used for new spec filenames:
+
+- `timestamp` (default): creates names like `20260509010203-billing-export`; collisions bump by one second until unused.
+- `counter`: creates names like `000001-billing-export` and persists the latest value in `spec.counter`.
+- `external`: requires an `id` in `spec new --data`; useful when another system owns the identifier.
+
+Names and ids are normalized to lowercase, with accepted separators such as `.`, `@`, `-`, and internal whitespace converted to hyphens. Leading or trailing whitespace, path separators, and control characters are rejected.
 
 ## Roadmap
 

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/jumppad-labs/spektacular/internal/agent"
+	"github.com/jumppad-labs/spektacular/internal/config"
 	"github.com/stretchr/testify/require"
 )
 
@@ -159,6 +160,12 @@ func TestInit_CustomCommand(t *testing.T) {
 	// Re-init — should use the custom command when rendering templates.
 	rootCmd.SetArgs([]string{"init", "claude"})
 	require.NoError(t, rootCmd.Execute())
+
+	cfg, err := config.FromYAMLFile(configPath)
+	require.NoError(t, err)
+	require.Equal(t, "go run .", cfg.Command)
+	require.Equal(t, "timestamp", cfg.Spec.IDMethod)
+	require.Equal(t, 0, cfg.Spec.Counter)
 
 	skillPath := filepath.Join(dir, ".claude", "skills", "spek-new", "SKILL.md")
 	skillData, err := os.ReadFile(skillPath)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,15 +27,22 @@ func Execute() {
 	}
 }
 
+func configFilePath() (string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("getting working directory: %w", err)
+	}
+	return filepath.Join(cwd, ".spektacular", "config.yaml"), nil
+}
+
 // loadConfig loads the project config from the current working directory.
 // Returns defaults if the config file does not exist.
 // Returns an error if the config file exists but is invalid.
 func loadConfig() (config.Config, error) {
-	cwd, err := os.Getwd()
+	cfgPath, err := configFilePath()
 	if err != nil {
-		return config.Config{}, fmt.Errorf("getting working directory: %w", err)
+		return config.Config{}, err
 	}
-	cfgPath := filepath.Join(cwd, ".spektacular", "config.yaml")
 	if _, err := os.Stat(cfgPath); os.IsNotExist(err) {
 		return config.NewDefault(), nil
 	}

--- a/cmd/spec.go
+++ b/cmd/spec.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/jumppad-labs/spektacular/internal/output"
 	"github.com/jumppad-labs/spektacular/internal/steps/spec"
@@ -17,6 +18,10 @@ import (
 )
 
 var nameRegexp = regexp.MustCompile(`^[a-z0-9_-]+$`)
+
+const identifierInputPattern = `^[^\s/\\\x00-\x1F\x7F](?:[^/\\\x00-\x1F\x7F]*[^\s/\\\x00-\x1F\x7F])?$`
+
+var specIdentifierNow = time.Now
 
 // Schema types for --schema output.
 type schemaProp struct {
@@ -94,6 +99,12 @@ func stateFilePath(dataDir string) string {
 	return filepath.Join(dataDir, "state.json")
 }
 
+type workflowDataBuffer map[string]any
+
+func (b workflowDataBuffer) SetData(key string, value any) {
+	b[key] = value
+}
+
 // readInputIntoWorkflow reads content from either --stdin or --file and stores
 // it in the workflow data. --stdin <key> reads from standard input and stores
 // under <key>. --file <path> reads the file at <path> (relative paths resolve
@@ -139,7 +150,8 @@ func runSpecNew(cmd *cobra.Command, _ []string) error {
 			Input: &schemaObj{
 				Type: "object",
 				Properties: map[string]*schemaProp{
-					"name": {Type: "string", Pattern: "^[a-z0-9_-]+$", MaxLen: 64},
+					"name": {Type: "string", Pattern: identifierInputPattern, MaxLen: spec.MaxIdentifierPartLength},
+					"id":   {Type: "string", Pattern: identifierInputPattern, MaxLen: spec.MaxIdentifierPartLength},
 				},
 				Required: []string{"name"},
 			},
@@ -156,12 +168,10 @@ func runSpecNew(cmd *cobra.Command, _ []string) error {
 	}
 	var input struct {
 		Name string `json:"name"`
+		ID   string `json:"id"`
 	}
 	if err := json.Unmarshal([]byte(dataStr), &input); err != nil {
 		return fmt.Errorf("parsing --data: %w", err)
-	}
-	if input.Name == "" || !nameRegexp.MatchString(input.Name) || len(input.Name) > 64 {
-		return fmt.Errorf("name must match ^[a-z0-9_-]+$ and be at most 64 characters")
 	}
 
 	dataDir, err := dataDir()
@@ -171,6 +181,35 @@ func runSpecNew(cmd *cobra.Command, _ []string) error {
 	cfg, err := loadConfig()
 	if err != nil {
 		return err
+	}
+
+	st := store.NewFileStore(dataDir)
+	extraData := workflowDataBuffer{}
+	if err := readInputIntoWorkflow(cmd, extraData); err != nil {
+		return err
+	}
+
+	resolved, err := spec.ResolveIdentifier(spec.IdentifierRequest{
+		Name:    input.Name,
+		ID:      input.ID,
+		Method:  cfg.Spec.IDMethod,
+		Counter: cfg.Spec.Counter,
+		Store:   st,
+		Now:     specIdentifierNow,
+	})
+	if err != nil {
+		return err
+	}
+
+	if !dryRun && resolved.Counter != cfg.Spec.Counter {
+		cfg.Spec.Counter = resolved.Counter
+		cfgPath, err := configFilePath()
+		if err != nil {
+			return err
+		}
+		if err := cfg.ToYAMLFile(cfgPath); err != nil {
+			return fmt.Errorf("writing config: %w", err)
+		}
 	}
 
 	statePath := stateFilePath(dataDir)
@@ -183,12 +222,13 @@ func runSpecNew(cmd *cobra.Command, _ []string) error {
 	wfCfg := workflow.Config{Command: cfg.Command, DryRun: dryRun}
 	steps := spec.Steps()
 	out := output.New(cmd.OutOrStdout(), globalFields)
-	wf := workflow.New(steps, statePath, wfCfg, store.NewFileStore(dataDir), out)
-	wf.SetData("name", input.Name)
-
-	if err := readInputIntoWorkflow(cmd, wf); err != nil {
-		return err
+	wf := workflow.New(steps, statePath, wfCfg, st, out)
+	for k, v := range extraData {
+		if k != "name" {
+			wf.SetData(k, v)
+		}
 	}
+	wf.SetData("name", resolved.Name)
 
 	if err := wf.Next(); err != nil {
 		return output.WriteError(cmd.ErrOrStderr(), err)

--- a/cmd/spec_test.go
+++ b/cmd/spec_test.go
@@ -1,0 +1,271 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/jumppad-labs/spektacular/internal/config"
+	"github.com/jumppad-labs/spektacular/internal/steps/spec"
+	"github.com/stretchr/testify/require"
+)
+
+type specCommandResult struct {
+	Step        string `json:"step"`
+	SpecPath    string `json:"spec_path"`
+	SpecName    string `json:"spec_name"`
+	Instruction string `json:"instruction"`
+}
+
+func writeSpecCommandConfig(t *testing.T, dir, body string) {
+	t.Helper()
+	dataDir := filepath.Join(dir, ".spektacular")
+	require.NoError(t, os.MkdirAll(dataDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dataDir, "config.yaml"), []byte(body), 0o644))
+}
+
+func writeSpecCommandFile(t *testing.T, dir, name string) {
+	t.Helper()
+	path := filepath.Join(dir, ".spektacular", "specs", name+".md")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte("existing"), 0o644))
+}
+
+func resetSpecCommandFlags(t *testing.T) {
+	t.Helper()
+	reset := func() {
+		require.NoError(t, specCmd.PersistentFlags().Set("schema", "false"))
+		require.NoError(t, specCmd.PersistentFlags().Set("dry-run", "false"))
+		require.NoError(t, specNewCmd.Flags().Set("data", ""))
+		require.NoError(t, specNewCmd.Flags().Set("stdin", ""))
+		require.NoError(t, specNewCmd.Flags().Set("file", ""))
+	}
+	reset()
+	t.Cleanup(reset)
+}
+
+func setSpecIdentifierNow(t *testing.T, now time.Time) {
+	t.Helper()
+	original := specIdentifierNow
+	specIdentifierNow = func() time.Time { return now }
+	t.Cleanup(func() {
+		specIdentifierNow = original
+	})
+}
+
+func runSpecNewForTest(t *testing.T, args ...string) (specCommandResult, error) {
+	t.Helper()
+	resetSpecCommandFlags(t)
+	stdout, _ := setupImplementCmd(t)
+	rootCmd.SetArgs(append([]string{"spec", "new"}, args...))
+
+	err := rootCmd.Execute()
+	if err != nil {
+		return specCommandResult{}, err
+	}
+
+	var result specCommandResult
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &result))
+	return result, nil
+}
+
+func runSpecNewSchemaForTest(t *testing.T) commandSchema {
+	t.Helper()
+	resetSpecCommandFlags(t)
+	stdout, _ := setupImplementCmd(t)
+	rootCmd.SetArgs([]string{"spec", "new", "--schema"})
+
+	require.NoError(t, rootCmd.Execute())
+
+	var schema commandSchema
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &schema))
+	return schema
+}
+
+func TestSpecNewSchemaDocumentsNameAndOptionalID(t *testing.T) {
+	schema := runSpecNewSchemaForTest(t)
+
+	require.Contains(t, schema.Input.Properties, "name")
+	require.Contains(t, schema.Input.Properties, "id")
+	require.Equal(t, []string{"name"}, schema.Input.Required)
+	require.Equal(t, spec.MaxIdentifierPartLength, schema.Input.Properties["name"].MaxLen)
+	require.Equal(t, spec.MaxIdentifierPartLength, schema.Input.Properties["id"].MaxLen)
+}
+
+func TestSpecNew_DefaultUsesTimestampPrefix(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	result, err := runSpecNewForTest(t, "--data", `{"name":"Billing.Export"}`)
+	require.NoError(t, err)
+
+	require.Equal(t, "overview", result.Step)
+	require.Regexp(t, regexp.MustCompile(`^\d{14}-billing-export$`), result.SpecName)
+	require.Equal(t, filepath.Join(dir, ".spektacular", "specs", result.SpecName+".md"), result.SpecPath)
+	require.FileExists(t, result.SpecPath)
+}
+
+func TestSpecNew_TimestampCollisionBumpsSeconds(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	setSpecIdentifierNow(t, time.Date(2026, time.May, 9, 1, 2, 3, 0, time.UTC))
+	writeSpecCommandFile(t, dir, "20260509010203-billing-export")
+
+	result, err := runSpecNewForTest(t, "--data", `{"name":"billing-export"}`)
+	require.NoError(t, err)
+
+	require.Equal(t, "20260509010204-billing-export", result.SpecName)
+	require.FileExists(t, filepath.Join(dir, ".spektacular", "specs", "20260509010203-billing-export.md"))
+	require.FileExists(t, result.SpecPath)
+}
+
+func TestSpecNew_ExplicitIDOverridesGeneratedMethod(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeSpecCommandConfig(t, dir, "spec:\n  id_method: counter\n  counter: 7\n")
+
+	result, err := runSpecNewForTest(t, "--data", `{"name":"Billing Export","id":"EXT.User@123"}`)
+	require.NoError(t, err)
+
+	require.Equal(t, "ext-user-123-billing-export", result.SpecName)
+	require.FileExists(t, result.SpecPath)
+
+	cfg, err := config.FromYAMLFile(filepath.Join(dir, ".spektacular", "config.yaml"))
+	require.NoError(t, err)
+	require.Equal(t, 7, cfg.Spec.Counter)
+}
+
+func TestSpecNew_ExternalModeWithIDCreatesSpec(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeSpecCommandConfig(t, dir, "spec:\n  id_method: external\n")
+
+	result, err := runSpecNewForTest(t, "--data", `{"name":"Billing Export","id":"EXT.User@123"}`)
+	require.NoError(t, err)
+
+	require.Equal(t, "ext-user-123-billing-export", result.SpecName)
+	require.FileExists(t, result.SpecPath)
+}
+
+func TestSpecNew_ExternalModeRequiresIDWithoutSideEffects(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	dataDir := filepath.Join(dir, ".spektacular")
+	writeSpecCommandConfig(t, dir, "spec:\n  id_method: external\n")
+
+	_, err := runSpecNewForTest(t, "--data", `{"name":"Billing Export"}`)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "id is required")
+	require.NoDirExists(t, filepath.Join(dataDir, "specs"))
+	require.NoFileExists(t, filepath.Join(dataDir, "state.json"))
+}
+
+func TestSpecNew_CounterModePersistsAdvancedCounter(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeSpecCommandConfig(t, dir, "spec:\n  id_method: counter\n  counter: 7\n")
+
+	result, err := runSpecNewForTest(t, "--data", `{"name":"billing-export"}`)
+	require.NoError(t, err)
+
+	require.Equal(t, "000008-billing-export", result.SpecName)
+	require.FileExists(t, result.SpecPath)
+
+	cfg, err := config.FromYAMLFile(filepath.Join(dir, ".spektacular", "config.yaml"))
+	require.NoError(t, err)
+	require.Equal(t, 8, cfg.Spec.Counter)
+}
+
+func TestSpecNew_StaleCounterCollisionPersistsBumpedCounter(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeSpecCommandConfig(t, dir, "spec:\n  id_method: counter\n  counter: 7\n")
+	writeSpecCommandFile(t, dir, "000008-billing-export")
+
+	result, err := runSpecNewForTest(t, "--data", `{"name":"billing-export"}`)
+	require.NoError(t, err)
+
+	require.Equal(t, "000009-billing-export", result.SpecName)
+	require.FileExists(t, result.SpecPath)
+
+	cfg, err := config.FromYAMLFile(filepath.Join(dir, ".spektacular", "config.yaml"))
+	require.NoError(t, err)
+	require.Equal(t, 9, cfg.Spec.Counter)
+}
+
+func TestSpecNew_DryRunReportsCanonicalNameWithoutWrites(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	dataDir := filepath.Join(dir, ".spektacular")
+	writeSpecCommandConfig(t, dir, "spec:\n  id_method: counter\n  counter: 7\n")
+
+	result, err := runSpecNewForTest(t, "--dry-run", "--data", `{"name":"billing-export"}`)
+	require.NoError(t, err)
+
+	require.Equal(t, "000008-billing-export", result.SpecName)
+	require.Equal(t, filepath.Join(dataDir, "specs", "000008-billing-export.md"), result.SpecPath)
+	require.NoFileExists(t, result.SpecPath)
+	require.NoFileExists(t, filepath.Join(dataDir, "state.json"))
+
+	cfg, err := config.FromYAMLFile(filepath.Join(dataDir, "config.yaml"))
+	require.NoError(t, err)
+	require.Equal(t, 7, cfg.Spec.Counter)
+}
+
+func TestSpecNew_ValidationFailuresLeaveNoSpecOrState(t *testing.T) {
+	tests := []struct {
+		name string
+		data string
+		want string
+	}{
+		{
+			name: "untrimmed name",
+			data: `{"name":" billing"}`,
+			want: "leading or trailing whitespace",
+		},
+		{
+			name: "path separator id",
+			data: `{"name":"billing","id":"bad/id"}`,
+			want: "path separators",
+		},
+		{
+			name: "untrimmed id",
+			data: `{"name":"billing","id":"ext "}`,
+			want: "leading or trailing whitespace",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			t.Chdir(dir)
+			dataDir := filepath.Join(dir, ".spektacular")
+
+			_, err := runSpecNewForTest(t, "--data", tt.data)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.want)
+			require.NoDirExists(t, filepath.Join(dataDir, "specs"))
+			require.NoFileExists(t, filepath.Join(dataDir, "state.json"))
+		})
+	}
+}
+
+func TestSpecNew_RejectsUnknownConfiguredIDMethod(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	dataDir := filepath.Join(dir, ".spektacular")
+	require.NoError(t, os.MkdirAll(dataDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dataDir, "config.yaml"), []byte("spec:\n  id_method: unsupported\n"), 0o644))
+
+	setupImplementCmd(t)
+	rootCmd.SetArgs([]string{"spec", "new", "--data", `{"name":"fixture"}`})
+
+	err := rootCmd.Execute()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "spec.id_method")
+	require.NoFileExists(t, filepath.Join(dataDir, "specs", "fixture.md"))
+	require.NoFileExists(t, filepath.Join(dataDir, "state.json"))
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,9 +10,21 @@ import (
 
 var envVarPattern = regexp.MustCompile(`\$\{([^}]+)\}`)
 
+const (
+	SpecIDMethodTimestamp = "timestamp"
+	SpecIDMethodCounter   = "counter"
+	SpecIDMethodExternal  = "external"
+)
+
 // DebugConfig holds debug logging configuration.
 type DebugConfig struct {
 	Enabled bool `yaml:"enabled"`
+}
+
+// SpecConfig holds configuration for specification creation.
+type SpecConfig struct {
+	IDMethod string `yaml:"id_method"`
+	Counter  int    `yaml:"counter"`
 }
 
 // Config is the top-level Spektacular configuration.
@@ -20,6 +32,7 @@ type Config struct {
 	Command string      `yaml:"command"`
 	Agent   string      `yaml:"agent"`
 	Debug   DebugConfig `yaml:"debug"`
+	Spec    SpecConfig  `yaml:"spec"`
 }
 
 // NewDefault returns a Config populated with default values.
@@ -28,6 +41,10 @@ func NewDefault() Config {
 		Command: "spektacular",
 		Debug: DebugConfig{
 			Enabled: false,
+		},
+		Spec: SpecConfig{
+			IDMethod: SpecIDMethodTimestamp,
+			Counter:  0,
 		},
 	}
 }
@@ -45,7 +62,28 @@ func FromYAMLFile(path string) (Config, error) {
 	if err := yaml.Unmarshal([]byte(expanded), &cfg); err != nil {
 		return Config{}, fmt.Errorf("parsing config file %s: %w", path, err)
 	}
+	if err := cfg.Validate(); err != nil {
+		return Config{}, fmt.Errorf("validating config file %s: %w", path, err)
+	}
 	return cfg, nil
+}
+
+// Validate checks whether the config contains supported values.
+func (c Config) Validate() error {
+	if err := c.Spec.Validate(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Validate checks whether the spec config contains supported values.
+func (c SpecConfig) Validate() error {
+	switch c.IDMethod {
+	case "", SpecIDMethodTimestamp, SpecIDMethodCounter, SpecIDMethodExternal:
+		return nil
+	default:
+		return fmt.Errorf("spec.id_method must be one of %q, %q, or %q", SpecIDMethodTimestamp, SpecIDMethodCounter, SpecIDMethodExternal)
+	}
 }
 
 // ToYAMLFile writes the Config to a YAML file.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -13,6 +13,8 @@ func TestNewDefault_HasExpectedDefaults(t *testing.T) {
 
 	require.Equal(t, "spektacular", cfg.Command)
 	require.False(t, cfg.Debug.Enabled)
+	require.Equal(t, "timestamp", cfg.Spec.IDMethod)
+	require.Equal(t, 0, cfg.Spec.Counter)
 }
 
 func TestFromYAMLFile_LoadsAndExpandsEnvVars(t *testing.T) {
@@ -27,6 +29,35 @@ func TestFromYAMLFile_LoadsAndExpandsEnvVars(t *testing.T) {
 	cfg, err := FromYAMLFile(path)
 	require.NoError(t, err)
 	require.Equal(t, "go run .", cfg.Command)
+	require.Equal(t, "timestamp", cfg.Spec.IDMethod)
+	require.Equal(t, 0, cfg.Spec.Counter)
+}
+
+func TestFromYAMLFile_MissingSpecConfigUsesDefaults(t *testing.T) {
+	yaml := `command: "go run ."`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	err := os.WriteFile(path, []byte(yaml), 0644)
+	require.NoError(t, err)
+
+	cfg, err := FromYAMLFile(path)
+	require.NoError(t, err)
+	require.Equal(t, "go run .", cfg.Command)
+	require.Equal(t, "timestamp", cfg.Spec.IDMethod)
+	require.Equal(t, 0, cfg.Spec.Counter)
+}
+
+func TestFromYAMLFile_UnknownSpecIDMethodReturnsError(t *testing.T) {
+	yaml := `spec:
+  id_method: unsupported`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	err := os.WriteFile(path, []byte(yaml), 0644)
+	require.NoError(t, err)
+
+	_, err = FromYAMLFile(path)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "spec.id_method")
 }
 
 func TestFromYAMLFile_MissingFile_ReturnsError(t *testing.T) {
@@ -46,4 +77,6 @@ func TestToYAMLFile_RoundTrip(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, cfg.Command, loaded.Command)
 	require.Equal(t, cfg.Debug.Enabled, loaded.Debug.Enabled)
+	require.Equal(t, cfg.Spec.IDMethod, loaded.Spec.IDMethod)
+	require.Equal(t, cfg.Spec.Counter, loaded.Spec.Counter)
 }

--- a/internal/project/init_test.go
+++ b/internal/project/init_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/jumppad-labs/spektacular/internal/config"
 	"github.com/stretchr/testify/require"
 )
 
@@ -38,6 +39,11 @@ func TestInit_CreatesConfigFile(t *testing.T) {
 	configPath := filepath.Join(dir, ".spektacular", "config.yaml")
 	_, err = os.Stat(configPath)
 	require.NoError(t, err, "config.yaml should exist")
+
+	cfg, err := config.FromYAMLFile(configPath)
+	require.NoError(t, err)
+	require.Equal(t, "timestamp", cfg.Spec.IDMethod)
+	require.Equal(t, 0, cfg.Spec.Counter)
 }
 
 func TestInit_CreatesGitignore(t *testing.T) {

--- a/internal/steps/spec/identifier.go
+++ b/internal/steps/spec/identifier.go
@@ -1,0 +1,192 @@
+package spec
+
+import (
+	"fmt"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/jumppad-labs/spektacular/internal/config"
+	"github.com/jumppad-labs/spektacular/internal/store"
+)
+
+const (
+	IDMethodTimestamp = config.SpecIDMethodTimestamp
+	IDMethodCounter   = config.SpecIDMethodCounter
+	IDMethodExternal  = config.SpecIDMethodExternal
+
+	MaxIdentifierPartLength = 64
+)
+
+// IdentifierRequest describes the data needed to resolve a canonical spec name.
+type IdentifierRequest struct {
+	Name    string
+	ID      string
+	Method  string
+	Counter int
+	Store   store.Store
+	Now     func() time.Time
+}
+
+// IdentifierResult is the canonical spec name and any updated counter state.
+type IdentifierResult struct {
+	Name    string
+	Counter int
+}
+
+// ResolveIdentifier turns a requested spec name plus optional id into a
+// canonical spec name.
+func ResolveIdentifier(req IdentifierRequest) (IdentifierResult, error) {
+	name, err := NormalizeIdentifierPart("name", req.Name)
+	if err != nil {
+		return IdentifierResult{}, err
+	}
+
+	method := req.Method
+	if method == "" {
+		method = IDMethodTimestamp
+	}
+	if err := validateMethod(method); err != nil {
+		return IdentifierResult{}, err
+	}
+
+	if req.ID != "" {
+		id, err := NormalizeIdentifierPart("id", req.ID)
+		if err != nil {
+			return IdentifierResult{}, err
+		}
+		resolved, err := resolveWithPrefix(req.Store, id, name)
+		if err != nil {
+			return IdentifierResult{}, err
+		}
+		return IdentifierResult{Name: resolved, Counter: req.Counter}, nil
+	}
+
+	switch method {
+	case IDMethodExternal:
+		return IdentifierResult{}, fmt.Errorf("id is required when spec.id_method is %q", IDMethodExternal)
+	case IDMethodTimestamp:
+		return resolveTimestamp(req, name)
+	case IDMethodCounter:
+		return resolveCounter(req, name)
+	default:
+		return IdentifierResult{}, fmt.Errorf("unsupported spec.id_method %q", method)
+	}
+}
+
+// NormalizeIdentifierPart normalizes one user-provided name/id component.
+func NormalizeIdentifierPart(label, raw string) (string, error) {
+	if raw == "" {
+		return "", fmt.Errorf("%s is required", label)
+	}
+	if len(raw) > MaxIdentifierPartLength {
+		return "", fmt.Errorf("%s must be at most %d characters", label, MaxIdentifierPartLength)
+	}
+	if raw != strings.TrimSpace(raw) {
+		return "", fmt.Errorf("%s must not have leading or trailing whitespace", label)
+	}
+
+	var b strings.Builder
+	lastHyphen := false
+	for _, r := range raw {
+		switch {
+		case r == '/' || r == '\\':
+			return "", fmt.Errorf("%s must not contain path separators", label)
+		case unicode.IsControl(r):
+			return "", fmt.Errorf("%s must not contain control characters", label)
+		case isASCIIAlnum(r):
+			b.WriteRune(toASCIILower(r))
+			lastHyphen = false
+		case r == '_':
+			b.WriteRune(r)
+			lastHyphen = false
+		case unicode.IsSpace(r) || unicode.IsPunct(r) || unicode.IsSymbol(r):
+			if !lastHyphen {
+				b.WriteByte('-')
+				lastHyphen = true
+			}
+		default:
+			return "", fmt.Errorf("%s contains unsupported character %q", label, r)
+		}
+	}
+
+	out := b.String()
+	if out == "" {
+		return "", fmt.Errorf("%s normalizes to empty", label)
+	}
+	return out, nil
+}
+
+func validateMethod(method string) error {
+	switch method {
+	case IDMethodTimestamp, IDMethodCounter, IDMethodExternal:
+		return nil
+	default:
+		return fmt.Errorf("unsupported spec.id_method %q", method)
+	}
+}
+
+func resolveTimestamp(req IdentifierRequest, name string) (IdentifierResult, error) {
+	now := req.Now
+	if now == nil {
+		now = time.Now
+	}
+
+	timestamp := now().UTC()
+	for {
+		resolved := fmt.Sprintf("%s-%s", timestamp.Format("20060102150405"), name)
+		exists, err := specExists(req.Store, resolved)
+		if err != nil {
+			return IdentifierResult{}, err
+		}
+		if !exists {
+			return IdentifierResult{Name: resolved, Counter: req.Counter}, nil
+		}
+		timestamp = timestamp.Add(time.Second)
+	}
+}
+
+func resolveCounter(req IdentifierRequest, name string) (IdentifierResult, error) {
+	counter := req.Counter + 1
+	for {
+		resolved := fmt.Sprintf("%06d-%s", counter, name)
+		exists, err := specExists(req.Store, resolved)
+		if err != nil {
+			return IdentifierResult{}, err
+		}
+		if !exists {
+			return IdentifierResult{Name: resolved, Counter: counter}, nil
+		}
+		counter++
+	}
+}
+
+func resolveWithPrefix(st store.Store, prefix, name string) (string, error) {
+	resolved := fmt.Sprintf("%s-%s", prefix, name)
+	exists, err := specExists(st, resolved)
+	if err != nil {
+		return "", err
+	}
+	if exists {
+		return "", fmt.Errorf("spec %q already exists", resolved)
+	}
+	return resolved, nil
+}
+
+func specExists(st store.Store, name string) (bool, error) {
+	if st == nil {
+		return false, fmt.Errorf("store required for spec identifier resolution")
+	}
+	return st.Exists(SpecFilePath(name)), nil
+}
+
+func isASCIIAlnum(r rune) bool {
+	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9')
+}
+
+func toASCIILower(r rune) rune {
+	if r >= 'A' && r <= 'Z' {
+		return r + ('a' - 'A')
+	}
+	return r
+}

--- a/internal/steps/spec/identifier_test.go
+++ b/internal/steps/spec/identifier_test.go
@@ -1,0 +1,228 @@
+package spec
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jumppad-labs/spektacular/internal/store"
+	"github.com/stretchr/testify/require"
+)
+
+func identifierStore(t *testing.T) store.Store {
+	t.Helper()
+	return store.NewFileStore(t.TempDir())
+}
+
+func writeExistingSpec(t *testing.T, st store.Store, name string) {
+	t.Helper()
+	require.NoError(t, st.Write(SpecFilePath(name), []byte("existing")))
+}
+
+func fixedIdentifierTime() time.Time {
+	return time.Date(2026, time.May, 8, 21, 2, 3, 0, time.FixedZone("EDT", -4*60*60))
+}
+
+func TestResolveIdentifier_DefaultTimestamp(t *testing.T) {
+	st := identifierStore(t)
+
+	got, err := ResolveIdentifier(IdentifierRequest{
+		Name:  "Billing.Export",
+		Store: st,
+		Now:   fixedIdentifierTime,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "20260509010203-billing-export", got.Name)
+	require.Equal(t, 0, got.Counter)
+}
+
+func TestResolveIdentifier_TimestampCollisionBumpsSeconds(t *testing.T) {
+	st := identifierStore(t)
+	writeExistingSpec(t, st, "20260509010203-billing-export")
+
+	got, err := ResolveIdentifier(IdentifierRequest{
+		Name:   "billing-export",
+		Method: IDMethodTimestamp,
+		Store:  st,
+		Now:    fixedIdentifierTime,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "20260509010204-billing-export", got.Name)
+	require.Equal(t, 0, got.Counter)
+}
+
+func TestResolveIdentifier_ExplicitTimestampMethod(t *testing.T) {
+	st := identifierStore(t)
+
+	got, err := ResolveIdentifier(IdentifierRequest{
+		Name:   "Billing@Export",
+		Method: IDMethodTimestamp,
+		Store:  st,
+		Now:    fixedIdentifierTime,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "20260509010203-billing-export", got.Name)
+}
+
+func TestResolveIdentifier_CounterUsesNextValue(t *testing.T) {
+	st := identifierStore(t)
+
+	got, err := ResolveIdentifier(IdentifierRequest{
+		Name:    "billing-export",
+		Method:  IDMethodCounter,
+		Counter: 7,
+		Store:   st,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "000008-billing-export", got.Name)
+	require.Equal(t, 8, got.Counter)
+}
+
+func TestResolveIdentifier_CounterCollisionBumpsValue(t *testing.T) {
+	st := identifierStore(t)
+	writeExistingSpec(t, st, "000008-billing-export")
+
+	got, err := ResolveIdentifier(IdentifierRequest{
+		Name:    "billing-export",
+		Method:  IDMethodCounter,
+		Counter: 7,
+		Store:   st,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "000009-billing-export", got.Name)
+	require.Equal(t, 9, got.Counter)
+}
+
+func TestResolveIdentifier_ExplicitIDOverridesGeneratedMethod(t *testing.T) {
+	st := identifierStore(t)
+
+	got, err := ResolveIdentifier(IdentifierRequest{
+		Name:    "Billing Export",
+		ID:      "EXT.User@123",
+		Method:  IDMethodCounter,
+		Counter: 7,
+		Store:   st,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "ext-user-123-billing-export", got.Name)
+	require.Equal(t, 7, got.Counter)
+}
+
+func TestResolveIdentifier_ExplicitIDCollisionFails(t *testing.T) {
+	st := identifierStore(t)
+	writeExistingSpec(t, st, "ext-123-billing")
+
+	_, err := ResolveIdentifier(IdentifierRequest{
+		Name:  "billing",
+		ID:    "EXT.123",
+		Store: st,
+	})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "already exists")
+}
+
+func TestResolveIdentifier_ExternalRequiresID(t *testing.T) {
+	st := identifierStore(t)
+
+	_, err := ResolveIdentifier(IdentifierRequest{
+		Name:   "billing",
+		Method: IDMethodExternal,
+		Store:  st,
+	})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "id is required")
+}
+
+func TestResolveIdentifier_ExternalUsesNormalizedID(t *testing.T) {
+	st := identifierStore(t)
+
+	got, err := ResolveIdentifier(IdentifierRequest{
+		Name:   "Billing Export",
+		ID:     "EXT.User@123",
+		Method: IDMethodExternal,
+		Store:  st,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "ext-user-123-billing-export", got.Name)
+}
+
+func TestResolveIdentifier_UnknownMethodReturnsError(t *testing.T) {
+	st := identifierStore(t)
+
+	_, err := ResolveIdentifier(IdentifierRequest{
+		Name:   "billing",
+		Method: "unsupported",
+		Store:  st,
+	})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unsupported spec.id_method")
+}
+
+func TestResolveIdentifier_RejectsUnsafeOrUntrimmedValuesBeforeStoreUse(t *testing.T) {
+	tests := []struct {
+		name string
+		req  IdentifierRequest
+		want string
+	}{
+		{
+			name: "leading whitespace name",
+			req:  IdentifierRequest{Name: " billing", Method: IDMethodTimestamp},
+			want: "leading or trailing whitespace",
+		},
+		{
+			name: "trailing whitespace id",
+			req:  IdentifierRequest{Name: "billing", ID: "ext ", Method: IDMethodTimestamp},
+			want: "leading or trailing whitespace",
+		},
+		{
+			name: "path separator name",
+			req:  IdentifierRequest{Name: "billing/export", Method: IDMethodTimestamp},
+			want: "path separators",
+		},
+		{
+			name: "control character id",
+			req:  IdentifierRequest{Name: "billing", ID: "bad\nid", Method: IDMethodTimestamp},
+			want: "control characters",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ResolveIdentifier(tt.req)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.want)
+		})
+	}
+}
+
+func TestResolveIdentifier_NilStoreFailsGeneratedModes(t *testing.T) {
+	tests := []struct {
+		name   string
+		method string
+	}{
+		{name: "default timestamp"},
+		{name: "timestamp", method: IDMethodTimestamp},
+		{name: "counter", method: IDMethodCounter},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ResolveIdentifier(IdentifierRequest{
+				Name:   "billing",
+				Method: tt.method,
+				Now:    fixedIdentifierTime,
+			})
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "store required")
+		})
+	}
+}

--- a/templates/skills/workflows/spek-new/SKILL.md
+++ b/templates/skills/workflows/spek-new/SKILL.md
@@ -5,7 +5,7 @@ description: Create a new Specification for a feature.
 
 # What this skill does
 
-This skill drives a **multi-step interactive workflow** that produces a complete specification file in `.spektacular/specs/<name>.md`. The workflow is owned by the `{{command}}` CLI, not by you — the CLI is the state machine and you are the executor.
+This skill drives a **multi-step interactive workflow** that produces a complete specification file at the `spec_path` returned by the CLI. The workflow is owned by the `{{command}}` CLI, not by you — the CLI is the state machine and you are the executor.
 
 On each turn, the CLI returns JSON containing an `instruction` field. That instruction describes exactly one step (e.g. overview, requirements, acceptance criteria, …). You must:
 
@@ -27,5 +27,13 @@ Start the spec workflow by running:
 ```
 {{command}} spec new --data '{"name": "<spec_name>"}'
 ```
+
+External systems may also supply an identifier with:
+
+```
+{{command}} spec new --data '{"name": "<spec_name>", "id": "<external_id>"}'
+```
+
+The CLI may normalize and prefix the requested name. Always use the returned `spec_name` and `spec_path` as the source of truth for follow-up workflows.
 
 This creates the spec file and state file automatically and returns the first `instruction`. From that point on, follow the loop above: do what the instruction says, then call `{{command}} spec goto --data '{"step":"<next_step>"}'` to get the next one. Do not invent step names — every instruction tells you the exact `goto` command to run next.

--- a/tests/harbor/spec-workflow/instruction.md
+++ b/tests/harbor/spec-workflow/instruction.md
@@ -8,22 +8,23 @@ The binary is already installed at `/usr/local/bin/spektacular`.
 First initialize the project:
 
 ```bash
-spektacular init claude
+spektacular init codex
 ```
 
 ## Task
 
 Create a specification for a **user authentication feature using JWT tokens** by
-using the `/spek:new` skill that was installed during init.
+driving the native `spektacular spec` workflow.
 
-Run the skill:
+Start the workflow:
 
+```bash
+spektacular spec new --data '{"name":"user-auth"}'
 ```
-/spek:new user-auth
-```
 
-The skill will guide you through the full spec workflow. Follow each instruction
-it gives you.
+The CLI returns JSON with a normalized, prefixed `spec_name` and `spec_path`.
+Use those returned values as the source of truth. Follow each instruction the
+CLI gives you, and advance with `spektacular spec goto --data '{"step":"..."}'`.
 
 When writing content for each section, use these details about the feature:
 - **What**: Stateless user authentication using JWT access and refresh tokens
@@ -44,5 +45,5 @@ cp -r /app/.spektacular /logs/artifacts/spektacular
 
 - The workflow reaches the `finished` or `done` state
 - All steps appear in the completed_steps list
-- The spec file at `.spektacular/specs/user-auth.md` contains content
+- The spec file at the returned `spec_path` contains content
 - Each spec section has meaningful, non-placeholder text

--- a/tests/harbor/spec-workflow/tests/test_spec_workflow.py
+++ b/tests/harbor/spec-workflow/tests/test_spec_workflow.py
@@ -13,8 +13,7 @@ from pathlib import Path
 PROJECT_DIR = Path("/app")
 SPEK_DIR = PROJECT_DIR / ".spektacular"
 STATE_FILE = SPEK_DIR / "state.json"
-SPEC_FILE = SPEK_DIR / "specs" / "user-auth.md"
-AGENT_TRANSCRIPT = Path("/logs/agent/claude-code.txt")
+AGENT_LOG_DIR = Path("/logs/agent")
 
 # The canonical step order as defined by the state machine in
 # internal/steps/spec/steps.go → Steps().
@@ -44,9 +43,17 @@ def load_state() -> dict:
     return json.loads(STATE_FILE.read_text())
 
 
+def spec_file_path() -> Path:
+    state = load_state()
+    spec_name = (state.get("data") or {}).get("name")
+    assert spec_name, "state.json has no data.name — cannot resolve spec file"
+    return SPEK_DIR / "specs" / f"{spec_name}.md"
+
+
 def load_spec() -> str:
-    assert SPEC_FILE.exists(), f"Spec file not found at {SPEC_FILE}"
-    return SPEC_FILE.read_text()
+    path = spec_file_path()
+    assert path.exists(), f"Spec file not found at {path}"
+    return path.read_text()
 
 
 def parse_sections(spec_text: str) -> dict[str, str]:
@@ -83,27 +90,34 @@ def extract_tool_calls() -> list[dict]:
 
     Each entry is {"command": "…"} for Bash tool_use blocks.
     """
-    assert AGENT_TRANSCRIPT.exists(), (
-        f"Agent transcript not found at {AGENT_TRANSCRIPT}"
-    )
+    transcripts = sorted(AGENT_LOG_DIR.glob("*.txt"))
+    assert transcripts, f"No agent transcripts found under {AGENT_LOG_DIR}"
 
     calls = []
-    for line in AGENT_TRANSCRIPT.read_text().splitlines():
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            obj = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-        if obj.get("type") != "assistant":
-            continue
-        msg = obj.get("message", {})
-        for block in msg.get("content", []):
-            if block.get("type") == "tool_use" and block.get("name") == "Bash":
-                cmd = block.get("input", {}).get("command", "")
-                if cmd:
-                    calls.append({"command": cmd})
+    for transcript in transcripts:
+        for line in transcript.read_text().splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if obj.get("type") == "item.completed":
+                item = obj.get("item", {})
+                if item.get("type") == "command_execution":
+                    cmd = item.get("command", "")
+                    if cmd:
+                        calls.append({"command": cmd})
+                    continue
+            if obj.get("type") != "assistant":
+                continue
+            msg = obj.get("message", {})
+            for block in msg.get("content", []):
+                if block.get("type") == "tool_use" and block.get("name") == "Bash":
+                    cmd = block.get("input", {}).get("command", "")
+                    if cmd:
+                        calls.append({"command": cmd})
     return calls
 
 
@@ -118,9 +132,18 @@ def find_spektacular_calls(tool_calls: list[dict]) -> list[str]:
         if "spektacular spec new" in cmd:
             results.append("spec new")
         elif "spektacular spec goto" in cmd:
-            m = re.search(r'"step"\s*:\s*"(\w+)"', cmd)
+            normalized = cmd.replace('\\"', '"').replace("\\'", "'")
+            m = re.search(r'["\']step["\']\s*:\s*["\']([a-z_]+)["\']', normalized)
             if m:
                 results.append(f"spec goto {m.group(1)}")
+                continue
+
+            for step in EXPECTED_STEP_ORDER:
+                if step == "new":
+                    continue
+                if re.search(rf"\b{re.escape(step)}\b", normalized):
+                    results.append(f"spec goto {step}")
+                    break
     return results
 
 
@@ -137,7 +160,8 @@ class TestWorkflow:
 
     def test_spec_file_exists(self):
         """The spec markdown file was created."""
-        assert SPEC_FILE.exists(), f"Spec file not found at {SPEC_FILE}"
+        path = spec_file_path()
+        assert path.exists(), f"Spec file not found at {path}"
 
     def test_workflow_reached_finished(self):
         """Workflow current_step is finished or done."""


### PR DESCRIPTION
## Why
Spektacular previously generated spec names from a slug-oriented local workflow. That made ordering, collision handling, external-system IDs, and future remote artifact backends harder to coordinate. This PR adds a configurable spec ID layer so new specs can use migration-style timestamps by default, deterministic counters when desired, or externally owned IDs when another system is the source of truth.

## What changed
- Adds `spec.id_method` with `timestamp` as the default, plus `counter` and `external` modes.
- Adds `spec.counter` so counter mode can persist and advance the current value during spec creation.
- Allows `spec new --data` to include an `id`; passed IDs are accepted in timestamp/counter projects and required in external mode.
- Adds normalization and validation for generated IDs and names: values are lowercased and supported separators/special characters such as `.`, `@`, and spaces are converted, while leading/trailing whitespace is rejected instead of silently trimmed.
- Handles timestamp collisions by bumping seconds until an unused spec prefix is found.
- Updates README/config docs, changelog, the `$spek-new` skill, and the Harbor spec workflow/CI setup.

## Review notes
- `timestamp` is now the default behavior for new installs.
- `external` is intentionally permissive for caller-provided IDs after validation because it is meant to support systems such as Notion that own identifier generation.
- This PR is the foundation for #5, where the Notion backend requires `spec.id_method: external`.

## Validation
- `go test ./...`
- Harbor Codex `gpt-5.5` spec workflow: `35/35`, reward `1.0`