### PR TITLE
Add Notion artifact sync backend

### DIFF
--- a/.agents/skills/spek-implement/SKILL.md
+++ b/.agents/skills/spek-implement/SKILL.md
@@ -22,7 +22,19 @@ Plan name: $ARGUMENTS
 
 If no plan name was provided, check `.spektacular/state.json` for an active plan under `data.name`. If one exists, ask the user whether they want to implement that plan, offering the option to name a different one. If no active plan is found, ask the user which plan to implement before proceeding.
 
-The plan file must already exist at `.spektacular/plans/<plan_name>/plan.md`. If it does not, stop and tell the user to run `go run . plan` first.
+Before enforcing the plan-file precondition, run:
+
+```
+go run . notion status
+```
+
+If the returned `status` is not `configured`, the plan file must already exist at `.spektacular/plans/<plan_name>/plan.md`. If it does not, stop and tell the user to run `go run . plan` first.
+
+If Notion mode is configured, the plan cache must exist under `.spektacular/cache/notion/plans/<plan_name>/plan.md`. If it is missing, fetch the Plan page, `context.md`, and `research.md` child pages through Notion MCP and record them with `go run . notion cache pull`. You can pull by Notion URL, page ID, or Spektacular external ID when another user or agent already created the work.
+
+During implementation, any step that changes a cached artifact must sync before advancing. Run `go run . notion cache prepare-push` with the latest Notion `remote_version`; if it returns `ready`, update Notion through MCP and then run `go run . notion cache commit-push` with the returned metadata. If it returns `merge_required`, stop and surface the merge request to the user/agent. After resolution, run `go run . notion cache resolve-merge`, retry `prepare-push`, update Notion, and then commit the returned metadata.
+
+Doctor/setup flow: if Notion databases are not linked or validation reports issues, run `go run . notion link` to validate existing data sources and `go run . notion doctor` for fixable/blocking reports. Only apply additive doctor repairs after explicit user approval.
 
 Start the implement workflow by running:
 

--- a/.agents/skills/spek-new/SKILL.md
+++ b/.agents/skills/spek-new/SKILL.md
@@ -34,6 +34,28 @@ External systems may also supply an identifier with:
 go run . spec new --data '{"name": "<spec_name>", "id": "<external_id>"}'
 ```
 
+## Notion artifact mode
+
+Before starting, run:
+
+```
+go run . notion status
+```
+
+If the returned `status` is `configured`, artifacts are Notion-backed. Use Notion MCP to create or fetch the Spec page first, then read its required `Spec ID` auto-increment value and returned metadata. Start the workflow with the Notion ID as the external identifier and include the normalized remote metadata:
+
+```
+go run . spec new --data '{"name":"<spec_name>","remote":{"notion_url":"<page_url>","page_id":"<page_id>","data_source_url":"<specs_data_source>","external_id":"<spec_id>","remote_version":"<last_edited_time>","title":"<title>"}}'
+```
+
+When the final spec content is ready, update the Notion Spec page body through Notion MCP first. Then submit the same content to Spektacular with the returned remote metadata so the local cache and manifest are aligned:
+
+```
+go run . spec goto --data '{"step":"finished","remote":{"notion_url":"<page_url>","page_id":"<page_id>","data_source_url":"<specs_data_source>","external_id":"<spec_id>","remote_version":"<new_last_edited_time>","title":"<title>"}}' --file .spektacular/tmp/spec_template.md
+```
+
+If Notion reports that the page changed since the local baseline, stop and use `go run . notion cache prepare-push` to surface the merge request. Present the baseline, local, and remote content to the user/agent, run `go run . notion cache resolve-merge` after resolution, then retry the Notion update.
+
 The CLI may normalize and prefix the requested name. Always use the returned `spec_name` and `spec_path` as the source of truth for follow-up workflows.
 
 This creates the spec file and state file automatically and returns the first `instruction`. From that point on, follow the loop above: do what the instruction says, then call `go run . spec goto --data '{"step":"<next_step>"}'` to get the next one. Do not invent step names — every instruction tells you the exact `goto` command to run next.

--- a/.agents/skills/spek-new/SKILL.md
+++ b/.agents/skills/spek-new/SKILL.md
@@ -5,7 +5,7 @@ description: Create a new Specification for a feature.
 
 # What this skill does
 
-This skill drives a **multi-step interactive workflow** that produces a complete specification file in `.spektacular/specs/<name>.md`. The workflow is owned by the `go run .` CLI, not by you — the CLI is the state machine and you are the executor.
+This skill drives a **multi-step interactive workflow** that produces a complete specification file at the `spec_path` returned by the CLI. The workflow is owned by the `go run .` CLI, not by you — the CLI is the state machine and you are the executor.
 
 On each turn, the CLI returns JSON containing an `instruction` field. That instruction describes exactly one step (e.g. overview, requirements, acceptance criteria, …). You must:
 
@@ -27,5 +27,13 @@ Start the spec workflow by running:
 ```
 go run . spec new --data '{"name": "<spec_name>"}'
 ```
+
+External systems may also supply an identifier with:
+
+```
+go run . spec new --data '{"name": "<spec_name>", "id": "<external_id>"}'
+```
+
+The CLI may normalize and prefix the requested name. Always use the returned `spec_name` and `spec_path` as the source of truth for follow-up workflows.
 
 This creates the spec file and state file automatically and returns the first `instruction`. From that point on, follow the loop above: do what the instruction says, then call `go run . spec goto --data '{"step":"<next_step>"}'` to get the next one. Do not invent step names — every instruction tells you the exact `goto` command to run next.

--- a/.agents/skills/spek-plan/SKILL.md
+++ b/.agents/skills/spek-plan/SKILL.md
@@ -28,4 +28,28 @@ Start the plan workflow by running:
 go run . plan new --data '{"name": "<spec_name>"}'
 ```
 
+## Notion artifact mode
+
+Before starting, run:
+
+```
+go run . notion status
+```
+
+If the returned `status` is `configured`, artifacts are Notion-backed. Ensure the Spec cache exists before planning. If another user or agent already created the spec, locate it by Notion URL, page ID, or external Spec ID; if it is missing locally, fetch the Spec page through Notion MCP and record it:
+
+```
+go run . notion cache pull --data '{"kind":"spec","name":"<spec_name>","content":"<spec_markdown>","remote":{"notion_url":"<page_url>","page_id":"<page_id>","data_source_url":"<specs_data_source>","external_id":"<spec_id>","remote_version":"<last_edited_time>","title":"<title>"}}'
+```
+
+Create or fetch the Plan row through Notion MCP before the write steps. Use the required `Plan ID` auto-increment value as `remote.external_id`. Create or fetch child pages for `context.md` and `research.md` under the Plan page. When submitting each artifact-changing step, update Notion first, then pass the returned metadata with the file:
+
+```
+go run . plan goto --data '{"step":"write_plan","remote":{"notion_url":"<plan_page_url>","page_id":"<plan_page_id>","data_source_url":"<plans_data_source>","external_id":"<plan_id>","remote_version":"<new_last_edited_time>","title":"<title>"}}' --file .spektacular/tmp/plan_template.md
+go run . plan goto --data '{"step":"write_context","context_remote":{"notion_url":"<context_page_url>","page_id":"<context_page_id>","data_source_url":"<plans_data_source>","external_id":"<context_id>","remote_version":"<new_last_edited_time>","title":"context.md"}}' --file .spektacular/tmp/context_template.md
+go run . plan goto --data '{"step":"write_research","research_remote":{"notion_url":"<research_page_url>","page_id":"<research_page_id>","data_source_url":"<plans_data_source>","external_id":"<research_id>","remote_version":"<new_last_edited_time>","title":"research.md"}}' --file .spektacular/tmp/research_template.md
+```
+
+Before any Notion update, use `go run . notion cache prepare-push` with the latest Notion `remote_version`. If it returns `merge_required`, stop and present the merge request; after resolution, run `go run . notion cache resolve-merge` and retry.
+
 This creates the plan file and state file automatically and returns the first `instruction`. From that point on, follow the loop above: do what the instruction says, then call `go run . plan goto --data '{"step":"<next_step>"}'` to get the next one. Do not invent step names — every instruction tells you the exact `goto` command to run next.

--- a/.github/workflows/build_and_deploy.yaml
+++ b/.github/workflows/build_and_deploy.yaml
@@ -3,24 +3,30 @@ on:
   push:
     branches:
       - "**"
+  pull_request:
+    branches:
+      - main
+
 jobs:
-  dagger_build:
+  build:
     name: Dagger Build and Test
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
 
     steps:
       - uses: actions/checkout@v4
 
       - name: Set keys
+        if: ${{ github.repository == 'jumppad-labs/spektacular' && github.event_name == 'push' }}
         run: |
           echo "${{secrets.QUILL_SIGN_P12}}" | base64 -d  > ./cert.p12
           echo "${{secrets.QUILL_NOTORY_KEY}}" > ./key.p8
           echo "QUILL_SIGN_PASSWORD=${{secrets.QUILL_SIGN_PASSWORD}}" >> $GITHUB_ENV
           echo "GITHUB_TOKEN=${{secrets.GH_TOKEN}}" >> $GITHUB_ENV
-      
-      - name: All
+
+      - name: All signed
+        if: ${{ github.repository == 'jumppad-labs/spektacular' && github.event_name == 'push' }}
         uses: dagger/dagger-for-github@v8.2.0
         with:
           verb: call
@@ -28,29 +34,41 @@ jobs:
           args: all --output=./output --src=. --github-token=GITHUB_TOKEN --notorize-cert=./cert.p12 --notorize-cert-password=QUILL_SIGN_PASSWORD --notorize-key=./key.p8 --notorize-id=${{secrets.QUILL_NOTARY_KEY_ID}} --notorize-issuer=${{secrets.QUILL_NOTARY_ISSUER}}
           version: "0.19.8"
           dagger-flags: "--progress=plain"
-      
+
+      - name: All unsigned
+        if: ${{ github.repository != 'jumppad-labs/spektacular' || github.event_name != 'push' }}
+        uses: dagger/dagger-for-github@v8.2.0
+        with:
+          verb: call
+          module: ./dagger
+          args: all --output=./output --src=.
+          version: "0.19.8"
+          dagger-flags: "--progress=plain"
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: archives
           path: |
             ./output
-  
+
   release:
     name: Create GitHub Release
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ github.repository == 'jumppad-labs/spektacular' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
-    needs: 
-      - dagger_build
+    needs:
+      - build
     environment:
       name: release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Set keys
         run: |
           echo "GITHUB_TOKEN=${{secrets.GH_TOKEN}}" >> $GITHUB_ENV
           echo "GEMFURY_TOKEN=${{secrets.FURY_TOKEN}}" >> $GITHUB_ENV
-      
+
       - uses: actions/checkout@v4
 
       - name: Download-Binaries
@@ -67,7 +85,7 @@ jobs:
           args: release --src=. --github-token=GITHUB_TOKEN --gemfury-token=GEMFURY_TOKEN --archives=./build_artifacts --output=./version.txt
           version: "0.19.8"
           dagger-flags: "--progress=plain"
-    
+
       - name: Set output
         id: setoutput
         run: |

--- a/.spektacular/plans/20260509154708-notion-artifact-sync/context.md
+++ b/.spektacular/plans/20260509154708-notion-artifact-sync/context.md
@@ -1,0 +1,153 @@
+# Context: 20260509154708-notion-artifact-sync
+
+## Current State Analysis
+
+The current configuration is intentionally small. `internal/config/config.go:13` defines the existing spec ID methods, `internal/config/config.go:24` defines `SpecConfig`, `internal/config/config.go:30` defines top-level `Config`, and `internal/config/config.go:38` sets defaults to timestamp IDs. Validation currently only checks `spec.id_method` at `internal/config/config.go:71`, so artifact backend validation has a clear home.
+
+Project initialization always creates the local artifact folders. `internal/project/init.go:23` builds `.spektacular`, `plans`, `specs`, and `knowledge` directories on every init, and `internal/project/init.go:38` writes default config only if missing. The Notion mode needs to avoid creating local artifact folders when the project is initialized directly into Notion artifact mode, while preserving existing local behavior.
+
+The current store abstraction is filesystem-shaped. `internal/store/store.go:14` defines read, write, delete, list, and exists operations over relative paths, and `internal/store/store.go:32` implements them with `FileStore`. This is a good local cache primitive, but it is not a good direct Notion abstraction because Notion has database schemas, required auto-increment identifiers, relations, remote versions, and conflict metadata.
+
+Spec creation already has the identifier behavior Notion mode needs. `internal/steps/spec/identifier.go:39` resolves canonical names, `internal/steps/spec/identifier.go:53` lets an explicit ID override generated methods, `internal/steps/spec/identifier.go:65` requires an ID for external mode, `internal/steps/spec/identifier.go:77` rejects trimming while normalizing punctuation and symbols, and `internal/steps/spec/identifier.go:129` and `internal/steps/spec/identifier.go:149` implement timestamp and counter generation.
+
+The CLI commands currently create file stores directly. `cmd/spec.go:186` creates a `FileStore` for spec workflows and `cmd/spec.go:192` resolves the spec identifier against that store. `cmd/plan.go:118` and `cmd/plan.go:173` create `FileStore` instances for plan workflows. `cmd/implement.go:112` requires a local plan file before implementation starts, which will fail for a Notion-backed plan until cache preparation happens first.
+
+Workflow state persistence needs careful handling. `internal/workflow/workflow.go:102` invokes step callbacks after transitions, while `internal/workflow/workflow.go:125` persists state on `enter_state`. If a Notion sync conflict is discovered too late, the state may already show the next step. The safest implementation is to perform sync validation before firing the transition or wrap workflow advancement with a Notion preflight that can block cleanly.
+
+Spec and plan step callbacks write local files at their terminal write points. `internal/steps/spec/steps.go:63` creates the initial spec scaffold, and `internal/steps/spec/steps.go:138` writes the final spec template. `internal/steps/plan/steps.go:178`, `internal/steps/plan/steps.go:195`, and `internal/steps/plan/steps.go:212` write plan, context, and research content from workflow data. Notion mode should preserve the same user-visible workflow cadence, using cache files where the filesystem workflow uses artifact files and syncing Notion at the same artifact-changing points.
+
+Path strategies currently assume local filesystem artifact paths. `internal/steps/spec/strategy.go:14`, `internal/steps/plan/strategy.go:14`, and `internal/steps/implement/strategy.go:31` build absolute paths from store root and local path conventions. Notion mode should keep returning local cache paths for agent editing and add remote metadata in result fields rather than replacing paths with Notion URLs.
+
+Agent skills currently describe local artifact workflows. `templates/skills/workflows/spek-new/SKILL.md:25` starts spec creation, `templates/skills/workflows/spek-plan/SKILL.md:25` starts plan creation, and `templates/skills/workflows/spek-implement/SKILL.md:25` requires the plan file to exist locally. These templates need Notion-aware instructions for enabled-mode detection, MCP calls, external IDs, pull-by-identity, cache sync, doctor approval, and merge resolution; the repo-local `.agents/skills` copies need to be regenerated or updated.
+
+The README documents local project layout and spec ID methods at `README.md:120` through `README.md:156`. That section needs to grow to describe artifact backends, Notion setup commands, the ignored cache, and conflict behavior.
+
+## Per-Phase Technical Notes
+
+### Phase 1.1: Configure Notion Artifacts
+
+- `internal/config/config.go:13` - add artifact backend constants, likely `local` and `notion`, next to the existing config constants.
+- `internal/config/config.go:24` - keep `SpecConfig` as-is but validate external ID when Notion is selected.
+- `internal/config/config.go:30` - add `Artifacts ArtifactsConfig` to top-level `Config`.
+- `internal/config/config.go:38` - default artifacts to local backend and a cache directory under `.spektacular/cache/notion`.
+- `internal/config/config.go:71` - extend validation to reject unsupported artifact backends, missing Notion data source URLs in Notion mode, missing required Spec ID/Plan ID property configuration, and Notion mode without `spec.id_method: external`.
+- `internal/config/config_test.go:12` - extend default, load, missing-field, unknown-value, and round-trip tests for artifact config.
+- `internal/project/init.go:23` - add an options struct or mode-aware path so direct Notion initialization can create the project root and cache path without generating local `specs` and `plans` folders.
+- `cmd/init.go:14` - add an artifact/backend flag only if regular `init` needs to initialize directly into Notion mode; otherwise keep regular init local and let the Notion command update config.
+
+**Complexity**: Medium
+**Token estimate**: ~18k
+**Agent strategy**: Single agent for config and init changes, with tests immediately after because these files are shared by every command.
+
+### Phase 1.2: Validate and Prepare Linked Notion Databases
+
+- `cmd/root.go:62` - register a new Notion command group.
+- New `cmd/notion.go` - add init, link, doctor, and status subcommands. Keep command output structured using existing schema/result patterns from `cmd/plan.go:16` and `cmd/spec.go:46`.
+- New `internal/notion/schema` package - define data source snapshots, required property rules, required auto-increment identifier fields, fixable issues, blocking issues, and report formatting.
+- New `internal/notion/setup` package or equivalent - convert schema reports into agent instructions for MCP create/update/fetch operations, including explicit approval before applying safe additive repairs.
+- `cmd/spec.go:108` - reuse `readInputIntoWorkflow` patterns or factor a common file/stdin reader for schema snapshots returned from MCP.
+- `internal/config/config.go:89` - write updated config only after link/init validation passes.
+- `internal/config/config_test.go:50` - add invalid Notion config tests and valid Notion config tests.
+- New command tests - cover compatible snapshots, missing required ID fields, missing fixable properties, incompatible property types, config write after success, explicit repair approval, and no config write after failure.
+
+**Complexity**: High
+**Token estimate**: ~35k
+**Agent strategy**: Parallel analysis is useful: one agent can define schema/report contracts while another sketches CLI command result shapes. Integration should be sequential to keep result formats consistent.
+
+### Phase 2.1: Add Artifact Cache and Manifest
+
+- New `internal/artifact` package - define artifact kind constants for spec, plan, context, and research, cache path resolution, checksum calculation, identity lookup, manifest loading, and manifest saving.
+- `internal/store/store.go:14` - continue using `FileStore` for actual local cache writes instead of making Notion implement this interface.
+- `internal/steps/spec/steps.go:11` and `internal/steps/plan/steps.go:11` - preserve existing local paths and add artifact-layer helpers that return cache paths in Notion mode.
+- `internal/steps/spec/strategy.go:14`, `internal/steps/plan/strategy.go:14`, and `internal/steps/implement/strategy.go:31` - route path variables through an artifact path resolver so instruction output points agents at the right local working copy.
+- `templates/.spektacular/.gitignore` - ensure the Notion cache directory and transient sync files are ignored.
+- New manifest tests - cover empty manifest creation, artifact upsert, Notion URL/page ID/external ID lookup, checksum changes, dirty status, stale remote status, and path traversal rejection.
+
+**Complexity**: Medium
+**Token estimate**: ~28k
+**Agent strategy**: Single agent, sequential execution. This package should be small and well-covered before workflow integration starts.
+
+### Phase 2.2: Add Pull, Push, and Conflict Contracts
+
+- New `cmd/artifact.go` or Notion subcommands - add cache update, prepare push, commit push, status, merge completion, and pull-result commands. Names can live under `notion cache` if that reads better in CLI help.
+- New `internal/artifact/sync` package - compare manifest remote baselines with agent-supplied remote metadata and return structured sync results or merge requests containing baseline, local, and remote content.
+- `cmd/spec.go:46`, `cmd/plan.go:16`, and `cmd/implement.go:20` - extend result schemas only if workflow outputs need sync status fields; keep backward compatibility for local mode.
+- New result structs - include status, changed artifacts, resolution needs, and merge request payloads.
+- Command tests - cover successful pull, pull by Notion URL/page ID/external ID, dirty local detection, safe push preparation, push commit, stale remote merge request, merge completion, missing manifest entry, and malformed remote metadata.
+- Notion MCP instructions - define the normalized fields the agent must return after MCP fetch/update: page URL, page ID, data source URL, external ID, last edited timestamp, title, relation URLs, and markdown content.
+
+**Complexity**: High
+**Token estimate**: ~40k
+**Agent strategy**: 2 agents can work in parallel if write scopes are split between command wiring and internal sync logic. Integration and error text should be reviewed sequentially.
+
+### Phase 3.1: Route Workflow Artifact Changes Through Sync
+
+- `cmd/spec.go:177` - load artifact config before store selection and select the right artifact service.
+- `cmd/spec.go:192` - in Notion mode, create the Notion Spec page first, read its required Spec ID auto-increment value, then pass that value through existing external identifier resolution.
+- `internal/steps/spec/steps.go:63` - in Notion mode, create or cache the Notion-backed scaffold in the Spec page body and manifest entry before returning overview.
+- `internal/steps/spec/steps.go:138` - sync final spec content through the artifact service before emitting finished output.
+- `cmd/plan.go:99` and `cmd/plan.go:161` - resolve Notion-backed spec and plan cache state before workflow creation and before each artifact-changing step, including lookup by existing external ID when another agent picks up work.
+- `internal/steps/plan/steps.go:178`, `internal/steps/plan/steps.go:195`, and `internal/steps/plan/steps.go:212` - route plan, context, and research writes through the artifact service in Notion mode; plan.md maps to the Plan page body, while context.md and research.md map to child pages under the Plan page.
+- `cmd/implement.go:112` - replace the raw local file precondition with artifact-cache preparation for Notion-backed plans.
+- `internal/workflow/workflow.go:102` and `internal/workflow/workflow.go:125` - avoid discovering conflicts after state persistence. Prefer a pre-transition sync guard in command code or a workflow callback extension that runs before state is persisted.
+- Workflow tests - cover unchanged local mode, Notion cache creation, sync success at the filesystem-equivalent step cadence, merge requests that block advancement, and implementation startup cache checks.
+
+**Complexity**: High
+**Token estimate**: ~50k
+**Agent strategy**: Parallel analysis for spec/plan/implement command surfaces, then sequential integration. This phase touches shared workflow behavior and should be kept behind artifact backend branches.
+
+### Phase 3.2: Update Skills, Docs, and Regression Coverage
+
+- `templates/skills/workflows/spek-new/SKILL.md:25` - add Notion mode behavior: detect enabled mode, use Notion MCP to create/fetch a spec artifact, pass the required Spec ID external identifier, and sync changed cache before each applicable step advancement.
+- `templates/skills/workflows/spek-plan/SKILL.md:25` - add Notion mode behavior: ensure spec cache exists, create/link a plan row with Plan ID, create context and research child pages, and sync changed artifacts.
+- `templates/skills/workflows/spek-implement/SKILL.md:25` - update the local plan precondition to allow Notion cache preparation or pull-by-identity before implementation starts.
+- `.agents/skills/spek-new/SKILL.md`, `.agents/skills/spek-plan/SKILL.md`, and `.agents/skills/spek-implement/SKILL.md` - update repo-local installed skills so this checkout uses the new instructions during implementation.
+- `templates/steps/spec/08-verification.md:1` and `templates/steps/plan/13-verification.md:1` - add Notion-specific sync reminders around final artifact submission where needed.
+- `README.md:120` - document local layout and Notion cache layout.
+- `README.md:138` - document artifact config and external ID requirement.
+- `README.md:166` - document which validation suites cover local mode versus Notion mode.
+- Harbor tests - keep existing local workflow tests passing and add a fake or dry Notion scenario for the agent sync protocol.
+
+**Complexity**: Medium
+**Token estimate**: ~30k
+**Agent strategy**: 2 agents can work in parallel if one owns docs/skills and one owns tests. Final verification should be sequential because templates and tests must agree on command names.
+
+## Testing Strategy
+
+Config tests should prove local defaults remain unchanged and Notion config is strictly validated. Schema validation tests should be table-driven with compatible, fixable, and blocking database snapshots, including missing required auto-increment identifier properties. Artifact cache tests should use temporary directories and deterministic remote metadata so dirty, stale, lookup, merge, and conflict states are easy to assert.
+
+Command tests should follow existing patterns in `cmd/spec_test.go` and `cmd/init_test.go`, using test helpers that reset Cobra flags between cases. Workflow tests should exercise both local mode and Notion mode so the current local path behavior remains protected.
+
+Harbor should continue validating the existing local spec and plan workflows. Add Notion protocol coverage only where it can be deterministic without a live Notion account; live MCP checks can remain manual until the MCP interaction can be fixture-backed.
+
+## Project References
+
+- Spec: `.spektacular/specs/20260509154708-notion-artifact-sync.md`
+- Current branch: `notion-artifact-sync-spec`
+- Prior PR this builds on: `https://github.com/jumppad-labs/spektacular/pull/4`
+- Notion base page used for spike: `https://www.notion.so/onboard-ai-developer-user-guide/Product-Engineering-Home-359b746f14ca80749eebd9c4400ffb4d`
+- Existing Specs data source from spike: `collection://6fa340fe-3aeb-4822-8772-19745d300027`
+- Existing Plans data source from spike: `collection://66115e12-ca84-4fb9-afa3-08fb5f74cbf5`
+- Required identity properties from example schema: `Spec ID` and `Plan ID`
+
+## Token Management Strategy
+
+| Tier | Token Budget | Agent Strategy |
+|------|-------------|----------------|
+| Low | ~10k | Single agent, sequential |
+| Medium | ~25k | 2-3 parallel agents with disjoint write scopes |
+| High | ~50k+ | Parallel analysis, sequential integration |
+
+Phase 1.1 and Phase 2.1 are good single-agent phases. Phase 1.2, Phase 2.2, and Phase 3.1 are high risk because they introduce new command contracts and workflow behavior. Phase 3.2 can be split if command names and result shapes are already stable.
+
+## Migration Notes
+
+Existing projects without an `artifacts` config block should load as local mode. Existing `.spektacular/specs` and `.spektacular/plans` content should not move automatically. Opting into Notion should be explicit through link or init, and any cache files created during Notion mode should remain ignored.
+
+Projects that already have a config file should preserve command, agent, debug, and spec fields when Notion setup writes artifact fields. Notion mode should set or require `spec.id_method: external`; it should not silently change the user's configured ID method outside the setup flow.
+
+## Performance Considerations
+
+Local mode should have no measurable performance change beyond config parsing a larger struct. Notion mode performance is dominated by MCP calls, so the binary should minimize redundant remote fetches by using manifest baselines and only requesting remote metadata for artifacts that are about to sync.
+
+Manifest operations should be small JSON reads and writes. Cache checksum calculation is proportional to artifact size, which is acceptable for markdown spec and plan documents.

--- a/.spektacular/plans/20260509154708-notion-artifact-sync/plan.md
+++ b/.spektacular/plans/20260509154708-notion-artifact-sync/plan.md
@@ -1,0 +1,357 @@
+# Plan: 20260509154708-notion-artifact-sync
+
+<!-- Metadata -->
+<!-- Created: 2026-05-09T16:23:52Z -->
+<!-- Commit: b7f6640 -->
+<!-- Branch: notion-artifact-sync-spec -->
+<!-- Repository: https://github.com/gregoryhunt/spektacular.git -->
+<!-- Slug: 0020-notion-artifact-sync -->
+
+## Overview
+
+Spektacular will add a Notion-backed artifact mode for specifications, plans, context, and research while preserving the existing local-only workflow. The shared Notion pages remain the team-visible source of truth, and the local cache remains the agent-friendly working copy with conflict metadata. This gives humans and agents a safer way to collaborate on the same planning artifacts without committing synced cache files to source control.
+
+## Architecture & Design Decisions
+
+The chosen architecture is an MCP-orchestrated Notion backend with a local cache and manifest. The Spektacular binary owns configuration, workflow state, schema rules, cache paths, local checksums, identity metadata, and conflict decisions; the agent performs Notion MCP operations only when the CLI requests external reads, writes, database creation, schema snapshots, or approved repairs. This keeps Notion authentication out of the binary while still making the binary the deterministic source of workflow behavior.
+
+Notion setup is always linked. Existing databases and databases created during setup both flow through the same validator, so there is no separate managed mode with surprising ownership semantics. The setup commands provide init, link, and doctor flows: init helps create missing databases through MCP, link validates existing databases before config is written, and doctor reports safe additive fixes. Applying those fixes follows the standard migration pattern: show the planned changes, ask the user or agent for explicit approval, then perform only the approved MCP updates.
+
+The local cache is a first-class artifact layer rather than a replacement for the current filesystem store. Local mode continues to use the existing specs and plans layout, while Notion mode uses a separate ignored cache namespace plus a manifest recording remote URLs, Notion page IDs, data source IDs, Spektacular external IDs, remote edit versions, and local checksums. Workflow steps keep the same user-visible cadence as the filesystem workflow: when a step creates, updates, or finalizes an artifact locally, Notion mode syncs the cache and manifest before returning the next instruction. If the remote artifact changed since the cache baseline, the step enters a merge flow with the baseline, local copy, and remote copy instead of advancing.
+
+Rejected options and evidence are captured in [research.md#alternatives-considered-and-rejected](./research.md#alternatives-considered-and-rejected). The main trade-off is that first-version Notion support depends on capable agents with MCP access, but it avoids embedding a second Notion auth stack into the binary and matches the user's requested operating model.
+
+## Component Breakdown
+
+- Configuration owns the artifact backend selection, cache directory, linked Notion locations, and required external ID mode. It also preserves existing local defaults when no artifact block is present.
+- Notion setup owns init, link, doctor, schema validation, required auto-increment identifier fields, and user-approved safe additive repairs. It produces structured instructions for MCP work, validates schema snapshots supplied back by the agent, and writes config only after validation passes.
+- Artifact cache owns path selection, manifest load/save, dirty detection, identity lookup, and conflict checks. It is deliberately separate from the existing file store so Notion metadata does not leak into generic filesystem reads and writes.
+- Merge flow owns stale-cache resolution. It presents the cache baseline, local content, and remote Notion content, then records the resolved content only after the user or agent explicitly chooses the merge outcome.
+- Workflow integration owns the points where spec, plan, and implement commands select local artifacts versus Notion cache artifacts. It ensures artifact-changing steps sync at the same cadence as the filesystem workflow and ensures implementation startup has a current local plan cache.
+- Skill and template updates own the agent-facing protocol. They teach agents when Notion mode is enabled, when to call Notion MCP, when to submit schema snapshots, when to sync changed cache files, how to pull existing work by identity, and how to surface merge conflicts to users.
+- Documentation and validation tests own the user-facing contract. They make the local workflow, Notion setup workflow, and conflict behavior understandable and regression-tested.
+
+## Data Structures & Interfaces
+
+The config contract adds an artifact block and keeps spec identifier behavior explicit:
+
+```go
+type ArtifactsConfig struct {
+    Backend  string
+    CacheDir string
+    Notion   NotionConfig
+}
+
+type NotionConfig struct {
+    BasePageURL     string
+    SpecsDataSource string
+    PlansDataSource string
+    SpecIDProperty  string
+    PlanIDProperty  string
+}
+```
+
+Schema validation uses a stable CLI-facing snapshot rather than parsing raw MCP markdown. Agents can build the snapshot from MCP fetch results, and the binary validates the contract:
+
+```go
+type DataSourceSnapshot struct {
+    URL        string
+    Properties map[string]PropertySnapshot
+}
+
+type SchemaReport struct {
+    Status   string
+    Fixable  []SetupIssue
+    Blocking []SetupIssue
+}
+```
+
+The cache manifest records local and remote baselines for each synced artifact:
+
+```go
+type ArtifactRef struct {
+    Kind             string
+    Name             string
+    LocalPath        string
+    RemoteURL        string
+    RemotePageID     string
+    DataSourceURL    string
+    ExternalID       string
+    RemoteLastEdited string
+    LocalChecksum    string
+}
+
+type Manifest struct {
+    Version   int
+    Artifacts []ArtifactRef
+}
+```
+
+Workflow and sync commands exchange structured outcomes so agents can react without scraping text:
+
+```go
+type SyncResult struct {
+    Status            string
+    ChangedArtifacts  []ArtifactRef
+    ResolutionNeeded  []ResolutionNeed
+}
+```
+
+Status values should stay small and stable: local, synced, stale, conflict, resolution_required, and not_configured.
+
+The merge contract should expose enough context for agent skills to guide the user:
+
+```go
+type MergeRequest struct {
+    Artifact ArtifactRef
+    Base     string
+    Local    string
+    Remote   string
+}
+```
+
+## Implementation Detail
+
+The implementation introduces an artifact service boundary above the current store. Local mode keeps using the existing file store directly, while Notion mode resolves cache paths, manifest entries, and sync requirements before the workflow code reads or writes artifacts. This keeps most existing workflow logic intact while giving Notion mode a place to enforce remote metadata and conflicts.
+
+Setup commands should be modeled as deterministic CLI workflows rather than hidden API clients. When the binary needs Notion information, it emits structured instructions asking the agent to call MCP and return a normalized snapshot. When the agent returns that snapshot, the binary validates it and writes config or emits a report. The same validator powers init, link, and doctor, and doctor apply should follow an industry-standard migration posture: report planned changes first, require explicit approval, apply only safe additive changes, then validate again.
+
+The Notion content layout follows the example workspace. The Spec database page body stores the spec markdown and exposes a required Spec ID auto-increment property. The Plan database page body stores plan.md, exposes a required Plan ID auto-increment property, relates back to the Spec, and owns Context and Research child pages.
+
+Step completion needs special care because the workflow currently persists state as it enters a step. Notion conflict checks that can block advancement should run before the workflow transitions or through a command wrapper that validates sync readiness before calling the FSM event. The implementation should avoid a state file that says a step advanced when the remote sync was rejected, and state or manifest metadata should retain active Notion page IDs and external IDs so other agents can pull existing work by shared identity.
+
+The skill changes are part of the feature, not documentation polish. In Notion mode, the skills must tell agents to create or fetch Notion pages through MCP, submit schema snapshots to the binary, submit changed artifact content through the cache/sync commands, pull existing work by URL/page ID/external ID, and stop on doctor approval or merge-resolution prompts.
+
+## Dependencies
+
+- Existing spec identifier work: provides timestamp, counter, external ID behavior, normalization, and external ID enforcement; this plan depends on that branch landing first.
+- Existing config package: provides YAML load, defaults, env expansion, and validation; it needs new artifact configuration and Notion-specific validation.
+- Existing workflow package: provides state transitions and command result flow; it needs a pre-transition or wrapper path for sync blocking.
+- Existing store package: provides safe local filesystem reads and writes; it remains the local backend and underpins the Notion cache.
+- Existing spec, plan, and implement commands: provide the workflow entry points that need artifact backend resolution and cache checks.
+- Notion MCP: provides actual Notion database and page operations; the binary should orchestrate it through agent instructions instead of importing a Notion client.
+- Notion auto-increment properties: provide the required Spec ID and Plan ID values used as stable external identifiers and lookup keys.
+- Harbor and Go tests: provide current regression coverage for workflows and CLI behavior; they need Notion-mode unit and scenario coverage.
+
+## Testing Approach
+
+Unit tests should cover config defaults and validation, required auto-increment schema validation, safe additive doctor behavior with approval, manifest read/write, identity lookup, checksum changes, stale remote detection, merge request generation, and Notion-required external spec IDs. Command tests should cover init, link, doctor, pull, push, merge completion, and the workflow entry points in both local and Notion modes.
+
+Workflow tests should focus on the load-bearing behavior: local mode remains unchanged, Notion mode writes to cache paths, changed artifacts update the manifest, conflicts produce resolution-required output, and implementation startup refuses to proceed without a usable plan cache. Skill/template tests should assert that installed agent skills include the Notion MCP and sync instructions when relevant.
+
+Harbor coverage should stay local-first for the existing scenarios and add at least one Notion-mode dry or fake-MCP scenario that verifies the agent follows the new sync protocol. Direct live Notion integration should remain manual or fixture-backed until the MCP contract can be exercised deterministically in CI.
+
+## Milestones & Phases
+
+### Milestone 1: Projects can be configured for linked Notion artifacts
+
+**What changes**: Users can tell Spektacular that artifacts live in Notion, validate existing databases, and initialize missing shared structure through a linked setup flow. Existing local projects continue to behave as they do today.
+
+#### - [x] Phase 1.1: Configure Notion artifacts
+
+Add the artifact backend configuration and make Notion mode require external spec identifiers. Local mode remains the default, and projects that do not opt into Notion see no behavior change.
+
+*Technical detail:* [context.md#phase-11-configure-notion-artifacts](./context.md#phase-11-configure-notion-artifacts)
+
+**Acceptance criteria**:
+
+- [x] A new default config keeps local artifacts and timestamp spec IDs.
+- [x] A Notion artifact config validates only when linked Notion locations and required Spec ID/Plan ID properties are present.
+- [x] A Notion artifact config fails validation unless spec IDs use the external method.
+- [x] Existing config files without an artifact block continue to load.
+- [x] Notion-mode initialization avoids creating local-only specs and plans artifact folders.
+
+#### - [x] Phase 1.2: Validate and prepare linked Notion databases
+
+Add the Notion setup command group and shared schema validator. Users can validate existing databases, receive fixable versus blocking issue reports, and initialize missing databases through MCP-guided steps.
+
+*Technical detail:* [context.md#phase-12-validate-and-prepare-linked-notion-databases](./context.md#phase-12-validate-and-prepare-linked-notion-databases)
+
+**Acceptance criteria**:
+
+- [x] Linking compatible Specs and Plans databases with required auto-increment ID fields writes project config after validation passes.
+- [x] Linking incompatible databases reports every blocking issue, including missing required ID fields, and leaves the project unconfigured.
+- [x] Doctor reports fixable and blocking issues separately.
+- [x] Doctor apply presents safe additive changes for approval, applies only approved changes, and a follow-up validation can pass.
+
+### Milestone 2: Notion artifacts have a safe local working cache
+
+**What changes**: Agents can pull Notion artifacts into an ignored local cache, edit the cache, and push changes only when the remote artifact has not changed since the local baseline. Conflicts are explicit and do not overwrite another user's work.
+
+#### - [x] Phase 2.1: Add artifact cache and manifest
+
+Introduce cache paths and manifest metadata for specs, plans, context, and research. The cache tracks local content checksums and remote versions so commands can distinguish clean, dirty, stale, and conflicting artifacts.
+
+*Technical detail:* [context.md#phase-21-add-artifact-cache-and-manifest](./context.md#phase-21-add-artifact-cache-and-manifest)
+
+**Acceptance criteria**:
+
+- [x] Notion-backed specs and plans resolve to cache paths outside the local artifact directories.
+- [x] Pulling an artifact records its remote URL, Notion page ID, data source URL, external ID, remote edit version, local path, and checksum.
+- [x] Pulling can locate existing work by Notion URL, Notion page ID, or Spektacular external ID.
+- [x] Editing a cached artifact changes its dirty status without modifying the remote baseline.
+- [x] The cache path is ignored by default.
+
+#### - [x] Phase 2.2: Add pull, push, and conflict contracts
+
+Add CLI contracts that let agents update cache files from MCP reads, prepare safe MCP writes, and commit returned remote metadata after a successful write. Conflict responses include the exact artifact and required resolution action.
+
+*Technical detail:* [context.md#phase-22-add-pull-push-and-conflict-contracts](./context.md#phase-22-add-pull-push-and-conflict-contracts)
+
+**Acceptance criteria**:
+
+- [x] Pull updates a cache file and manifest from agent-supplied Notion content and metadata.
+- [x] Push preparation returns a merge request when the supplied remote version does not match the manifest baseline.
+- [x] Merge completion records the resolved content and only then allows retrying the Notion update.
+- [x] A successful push commit updates the manifest to the new remote version.
+- [x] Conflict output is structured enough for an agent to present the resolution need without guessing.
+
+### Milestone 3: Workflows and skills use Notion artifacts end to end
+
+**What changes**: Spec, plan, and implement workflows can operate against Notion-backed artifacts through the cache and sync layer. The installed skills tell agents how to use Notion MCP and when to stop for conflicts.
+
+#### - [x] Phase 3.1: Route workflow artifact changes through sync
+
+Update spec, plan, and implement workflow commands so Notion mode creates or refreshes cache entries, syncs changed artifacts before returning the next instruction, and blocks step advancement on conflicts.
+
+*Technical detail:* [context.md#phase-31-route-workflow-artifact-changes-through-sync](./context.md#phase-31-route-workflow-artifact-changes-through-sync)
+
+**Acceptance criteria**:
+
+- [x] Notion-backed spec creation uses the required Notion Spec ID auto-increment value as the external identifier and creates a matching cache entry.
+- [x] Notion-backed plan creation links to the spec and creates plan, context, and research cache entries.
+- [x] Each successful artifact-changing step syncs at the same user-visible point as the filesystem workflow and leaves cache content and manifest metadata aligned with the latest remote version.
+- [x] Implementation startup prepares or rejects the Notion-backed plan cache before the implementation workflow reads it.
+
+#### - [x] Phase 3.2: Update skills, docs, and regression coverage
+
+Update the embedded and repo-local skills, README guidance, and regression tests so agents and users understand the Notion setup and sync protocol. Existing local workflow coverage remains in place.
+
+*Technical detail:* [context.md#phase-32-update-skills-docs-and-regression-coverage](./context.md#phase-32-update-skills-docs-and-regression-coverage)
+
+**Acceptance criteria**:
+
+- [x] Installed skills describe Notion MCP setup, enabled-mode detection, pull-by-identity, external IDs, per-step sync responsibilities, doctor approval, and merge resolution.
+- [x] README documents local mode, Notion mode, link, init, doctor, cache, and conflict behavior.
+- [x] Existing local workflow tests still pass.
+- [x] New Notion-mode tests cover config, setup validation, cache sync, conflict output, and workflow startup behavior.
+
+## Open Questions
+
+None are intentionally carried into implementation. If the observed Notion MCP fetch or update payload shape differs from the spike enough that it cannot be normalized into the planned snapshot contracts, implementation should stop and adjust the contract before changing workflow behavior.
+
+## Out of Scope
+
+- Syncing knowledge-base content to or from Notion is out of scope for this plan.
+- Syncing implementation artifacts, generated code, test output, or build artifacts to Notion is out of scope.
+- Embedding direct Notion API authentication or an HTTP Notion client in the binary is out of scope for the first version.
+- Automatically merging conflicting local and remote edits is out of scope; this plan detects and blocks conflicts.
+- Deleting, renaming, or changing incompatible existing Notion database properties automatically is out of scope.
+- Replacing the current local-only filesystem workflow is out of scope.
+- Building a general-purpose Notion database migration framework is out of scope.
+
+## Changelog
+
+### 2026-05-09 — Phase 1.1: Configure Notion artifacts
+
+**What was done**: Added artifact backend configuration with local defaults, Notion cache settings, linked data source fields, required Spec ID/Plan ID property names, and validation that Notion mode requires external spec IDs. Added a mode-aware project initializer that future Notion setup commands can use to create the project metadata and Notion cache without creating local-only spec and plan artifact folders.
+
+**Deviations**: None. The regular `init <agent>` command remains local-only by design; Notion setup uses the dedicated Notion command flow.
+
+**Files changed**:
+- `internal/config/config.go`
+- `internal/config/config_test.go`
+- `internal/project/init.go`
+- `internal/project/init_test.go`
+
+**Discoveries**: `InitWithOptions` needs a fully valid Notion config when writing Notion mode, because normal config loading now validates required data source and identifier-property fields. That fits the planned `notion init/link` flow, which should write Notion config only after schema validation has returned the linked data source IDs.
+
+### 2026-05-09 — Phase 1.2: Validate and prepare linked Notion databases
+
+**What was done**: Added a `notion` command group with `init`, `link`, `doctor`, and `status` subcommands. Added Notion data source snapshot parsing, linked Specs/Plans schema validation, blocking versus fixable issue reports, safe additive repair preparation, and config writing only after compatible snapshots validate. The commands accept JSON snapshots from Notion MCP directly or through snapshot files, and Notion mode initializes the project cache without creating local specs/plans artifact folders.
+
+**Deviations**: None.
+
+**Files changed**:
+- `cmd/notion.go`
+- `cmd/notion_test.go`
+- `cmd/root.go`
+- `internal/notion/schema/parse.go`
+- `internal/notion/schema/schema.go`
+- `internal/notion/schema/schema_test.go`
+- `internal/notion/setup/instructions.go`
+
+**Discoveries**: Notion MCP fetch output can be passed through as a wrapped JSON/text payload containing `<data-source-state>`, so the validator supports both direct snapshots and MCP fetch wrappers. The example databases use `auto_increment_id` in fetched schema output for `Spec ID` and `Plan ID`, while MCP create DDL represents those fields as `UNIQUE_ID`. Because the project uses Notion MCP as the integration boundary, `doctor --apply` prepares approved MCP update instructions and patched local snapshots rather than mutating Notion directly.
+
+### 2026-05-09 — Phase 2.1: Add artifact cache and manifest
+
+**What was done**: Added the `internal/artifact` package with artifact kind constants, local versus Notion cache path resolution, checksum calculation, manifest load/save, pull recording, identity lookup, and cache status checks for dirty and stale artifacts. Updated the embedded `.spektacular/.gitignore` template so `cache/notion/` and transient sync files are ignored by default.
+
+**Deviations**: None. Workflow path routing was intentionally deferred to Phase 3.1 after the cache and manifest primitives existed.
+
+**Files changed**:
+- `internal/artifact/artifact.go`
+- `internal/artifact/artifact_test.go`
+- `internal/project/init_test.go`
+- `templates/.spektacular/.gitignore`
+
+**Discoveries**: Keeping the manifest store-relative lets the existing `FileStore` handle all path safety checks, while artifact names still need explicit separator validation before cache path construction.
+
+### 2026-05-09 — Phase 2.2: Add pull, push, and conflict contracts
+
+**What was done**: Added an `internal/artifact/sync` package and `notion cache` subcommands for `pull`, `status`, `prepare-push`, `commit-push`, and `resolve-merge`. Pull records Notion MCP content and metadata in the cache and manifest, prepare-push returns either clean/ready status or a structured merge request, resolve-merge records remote baseline plus resolved local content, and commit-push records the returned remote version after a successful Notion update.
+
+**Deviations**: None.
+
+**Files changed**:
+- `cmd/notion_cache.go`
+- `cmd/notion_cache_test.go`
+- `internal/artifact/artifact.go`
+- `internal/artifact/artifact_test.go`
+- `internal/artifact/sync/sync.go`
+- `internal/artifact/sync/sync_test.go`
+
+**Discoveries**: Merge requests need a baseline content copy, not only a checksum. The manifest now tracks `baseline_path`, and pull/commit/merge resolution keep that baseline separate from the editable local cache file. The commands remain binary-local contracts around agent-supplied MCP content and metadata, so the binary does not call Notion directly.
+
+### 2026-05-09 — Phase 3.1: Route workflow artifact changes through sync
+
+**What was done**: Extended workflow runtime config with the loaded project config and added config-aware path strategies so spec, plan, and implement workflows emit cache paths in Notion mode while local mode remains unchanged. Spec creation now uses the Notion-provided external ID, writes the scaffold to cache, and records a manifest entry; plan write steps write plan/context/research cache entries when remote metadata is supplied; implement startup checks the Notion plan cache path instead of the local plan path.
+
+**Deviations**: None.
+
+**Files changed**:
+- `cmd/implement.go`
+- `cmd/notion_workflow_test.go`
+- `cmd/plan.go`
+- `cmd/spec.go`
+- `internal/artifact/artifact.go`
+- `internal/artifact/sync/sync.go`
+- `internal/stepkit/stepkit.go`
+- `internal/steps/implement/strategy.go`
+- `internal/steps/plan/steps.go`
+- `internal/steps/plan/strategy.go`
+- `internal/steps/spec/steps.go`
+- `internal/steps/spec/strategy.go`
+- `internal/workflow/workflow.go`
+
+**Discoveries**: The least invasive path integration is an optional config-aware strategy interface in `stepkit`. It keeps existing local strategy behavior intact while allowing Notion mode to resolve the same artifact names to cache paths. Notion-backed artifact-changing steps require the agent to supply returned Notion metadata so the binary can record cache and manifest baselines while keeping MCP as the Notion integration boundary.
+
+### 2026-05-09 — Phase 3.2: Update skills, docs, and regression coverage
+
+**What was done**: Updated the embedded workflow skills, repo-local installed skills, final spec/plan verification templates, and README with Notion mode setup and sync guidance. Added regression coverage that installed skills include Notion mode instructions, while the earlier Notion tests cover config validation, schema validation, cache sync, conflict output, and workflow startup behavior.
+
+**Deviations**: Harbor remains covered by the existing local workflow scenarios; Notion-mode coverage is command/unit level because live MCP interaction is fixture/manual until deterministic MCP harness support exists.
+
+**Files changed**:
+- `.agents/skills/spek-implement/SKILL.md`
+- `.agents/skills/spek-new/SKILL.md`
+- `.agents/skills/spek-plan/SKILL.md`
+- `README.md`
+- `cmd/init_test.go`
+- `templates/skills/workflows/spek-implement/SKILL.md`
+- `templates/skills/workflows/spek-new/SKILL.md`
+- `templates/skills/workflows/spek-plan/SKILL.md`
+- `templates/steps/plan/13-verification.md`
+- `templates/steps/spec/08-verification.md`
+
+**Discoveries**: The installed repo-local skills are rendered copies, not symlinks to the templates, so both the embedded templates and `.agents/skills` copies must be updated when command flow changes.

--- a/.spektacular/plans/20260509154708-notion-artifact-sync/research.md
+++ b/.spektacular/plans/20260509154708-notion-artifact-sync/research.md
@@ -1,0 +1,114 @@
+# Research: 20260509154708-notion-artifact-sync
+
+## Alternatives considered and rejected
+
+### Option A: Implement a direct Notion API client inside the binary
+
+The binary could authenticate to Notion, create databases, read pages, write pages, and manage conflicts without agent assistance.
+
+**Rejected**: The user specifically asked to use Notion MCP, and the first-version scope explicitly keeps Notion authentication and workspace access in the MCP layer. The existing binary has no external service client pattern for this feature, and adding one would expand scope beyond artifact orchestration.
+
+### Option B: Treat Notion as another `store.Store`
+
+The existing `Store` interface could get a Notion implementation, letting current spec and plan steps keep calling read and write methods.
+
+**Rejected**: `internal/store/store.go:14` is intentionally filesystem-shaped: it reads, writes, deletes, lists, and checks relative paths. Notion artifacts need database schema validation, required auto-increment identifiers, relations, remote page versions, child pages, merge requests, and conflict metadata. Forcing that into `Store` would hide the behavior this feature is meant to make explicit.
+
+### Option C: Managed versus linked Notion modes
+
+Spektacular could have one mode where it owns databases it creates and another mode where it only links to existing databases.
+
+**Rejected**: The user rejected this model for teams and clarified that linked is how Spektacular should always work. Init and doctor can still create or repair missing structure, but all databases are treated as linked databases after setup.
+
+### Option D: Commit Notion cache files in the existing local artifact folders
+
+Notion-backed specs and plans could use `.spektacular/specs` and `.spektacular/plans` directly so existing code paths need fewer changes.
+
+**Rejected**: The user wants local files to act as a cache and not be committed to git. Reusing the existing artifact folders would blur local-only artifacts with synced Notion cache content and make accidental commits more likely.
+
+## Chosen approach - evidence
+
+Config has a clear extension point. `internal/config/config.go:30` owns the top-level config shape, `internal/config/config.go:38` owns defaults, and `internal/config/config.go:71` owns validation. Adding an artifact backend block there matches current patterns.
+
+The spec ID prerequisite is already implemented. `internal/steps/spec/identifier.go:53` accepts explicit external IDs even when another generated method is configured, and `internal/steps/spec/identifier.go:65` requires an ID in external mode. That supports the requirement that Notion-backed specs use a Notion-derived external ID.
+
+The Notion MCP spike showed that the example database already provides the stable identity shape this feature should require. Specs expose a `Spec ID` auto-increment property and Plans expose a `Plan ID` auto-increment property, so those properties should be required rather than optional for Spektacular-compatible Notion schemas.
+
+The existing local workflow is file-store oriented. `cmd/spec.go:186`, `cmd/plan.go:118`, and `cmd/plan.go:173` construct `FileStore` instances directly, while `internal/steps/spec/steps.go:63` and `internal/steps/plan/steps.go:178` write artifacts through that store. This points to an artifact layer above the store rather than replacing the store itself.
+
+Workflow persistence can be a conflict risk. `internal/workflow/workflow.go:102` runs step callbacks after events, while `internal/workflow/workflow.go:125` persists state on entry. A Notion sync conflict should be detected before a transition is persisted or through a wrapper that prevents the transition from firing.
+
+The Notion MCP spike showed the target workspace is workable. The base page exposed Specs and Plans databases, the Specs database had Status, Approval, Tags, relation, and auto-increment fields, and the Plans database had reciprocal Spec relation, compatible status fields, and auto-increment identity. Creating a Plan with the Spec relation set to the Spec page URL populated the reverse relation automatically. Spec content can live in the Spec page body. Plan content can live in the Plan page body, with Context and Research represented as child pages under the Plan row.
+
+The current skill templates are local-only. `templates/skills/workflows/spek-new/SKILL.md:25`, `templates/skills/workflows/spek-plan/SKILL.md:25`, and `templates/skills/workflows/spek-implement/SKILL.md:25` all assume local artifact files. Updating skills is required because most users exercise Spektacular through agent skills; agents need enabled-mode detection, MCP operation instructions, external ID handling, pull-by-identity guidance, doctor approval prompts, cache sync instructions, and merge-resolution behavior.
+
+## Files examined
+
+- `AGENTS.md` - delegates repo-specific instructions to `.tessl/RULES.md`.
+- `.tessl/RULES.md` - contains no extra operational rules beyond the managed include note.
+- `.spektacular/specs/20260509154708-notion-artifact-sync.md` - source specification for this plan.
+- `internal/config/config.go:13` - existing spec ID constants and config defaults.
+- `internal/config/config.go:71` - current validation entry point.
+- `internal/config/config_test.go:12` - current default and round-trip config tests to extend.
+- `internal/project/init.go:23` - current init always creates local artifact directories.
+- `internal/project/init_test.go:12` - current directory structure expectations to update or preserve per mode.
+- `cmd/root.go:62` - root command registration point for a new Notion command group.
+- `cmd/init.go:14` - existing init command and agent installation flow.
+- `cmd/spec.go:147` - spec new command parses ID, loads config, resolves identifier, and creates workflow.
+- `cmd/spec.go:186` - spec workflow currently uses `FileStore` directly.
+- `cmd/spec_test.go:67` - tests document the spec schema and identifier behavior.
+- `internal/steps/spec/identifier.go:39` - canonical name resolution with timestamp, counter, and external methods.
+- `internal/steps/spec/identifier_test.go:23` - table coverage for timestamp, counter, external, normalization, and collisions.
+- `internal/steps/spec/steps.go:63` - spec scaffold write point.
+- `internal/steps/spec/steps.go:138` - final spec write point.
+- `cmd/plan.go:68` - plan new command creates workflow state without creating documents.
+- `cmd/plan.go:131` - plan goto command accepts workflow data and file uploads.
+- `internal/steps/plan/steps.go:178` - plan.md write point.
+- `internal/steps/plan/steps.go:195` - context.md write point.
+- `internal/steps/plan/steps.go:212` - research.md write point.
+- `internal/steps/plan/steps_test.go:67` - plan workflow order and write-step expectations.
+- `cmd/implement.go:112` - implementation startup currently requires a local plan file before workflow creation.
+- `internal/workflow/workflow.go:102` - step callbacks run after FSM events.
+- `internal/workflow/workflow.go:125` - state persists on enter_state.
+- `internal/store/store.go:14` - filesystem store contract.
+- `internal/steps/spec/strategy.go:14` - spec instruction path variables.
+- `internal/steps/plan/strategy.go:14` - plan instruction path variables.
+- `internal/steps/implement/strategy.go:31` - implement instruction path variables.
+- `templates/steps/spec/08-verification.md:1` - final spec submission instruction.
+- `templates/steps/plan/13-verification.md:1` - final plan/context/research submission instruction.
+- `templates/skills/workflows/spek-new/SKILL.md:25` - local spec workflow start instructions.
+- `templates/skills/workflows/spek-plan/SKILL.md:25` - local plan workflow start instructions.
+- `templates/skills/workflows/spek-implement/SKILL.md:25` - local implement workflow start instructions.
+- `README.md:120` - local project layout docs.
+- `README.md:138` - config and spec ID method docs.
+- `README.md:166` - current testing documentation.
+- `tests/harbor/spec-workflow/tests/test_spec_workflow.py` - Harbor coverage for spec workflow behavior.
+- `tests/harbor/plan-workflow/tests/test_plan_workflow.py` - Harbor coverage for plan workflow behavior.
+
+## External references
+
+- Notion MCP enhanced markdown spec resource, `notion://docs/enhanced-markdown-spec` - used to understand the page content format returned by Notion MCP fetches.
+- Product Engineering Home, `https://www.notion.so/onboard-ai-developer-user-guide/Product-Engineering-Home-359b746f14ca80749eebd9c4400ffb4d` - base page supplied by the user for testing and schema discovery.
+- Specs data source, `collection://6fa340fe-3aeb-4822-8772-19745d300027` - existing compatible Notion Specs database from the spike.
+- Plans data source, `collection://66115e12-ca84-4fb9-afa3-08fb5f74cbf5` - existing compatible Notion Plans database from the spike.
+- Required Notion identity properties from the example workspace - `Spec ID` and `Plan ID` auto-increment fields, used as stable external identifiers.
+- Spike spec page, `https://www.notion.so/35bb746f14ca81ada4b3e4ac56401b63` - throwaway MCP-created spec row, later marked Superseded.
+- Spike plan page, `https://www.notion.so/35bb746f14ca811d9b10f0ab4ab0213c` - throwaway MCP-created plan row, later marked Superseded.
+
+## Prior plans / specs consulted
+
+- `.spektacular/specs/20260509154708-notion-artifact-sync.md` - primary source of requirements, constraints, acceptance criteria, and non-goals.
+- Prior spec ID prefix work on branch `spec-id-prefix-method` and PR `https://github.com/jumppad-labs/spektacular/pull/4` - provides external ID behavior, normalization, counter state, and timestamp collision behavior that Notion mode must build on.
+
+## Open assumptions
+
+- Agents implementing this feature will have Notion MCP access when running Notion setup and sync flows.
+- The binary can rely on agents to normalize MCP fetch results into stable schema and page-content snapshots before passing them back to CLI commands.
+- Notion `last_edited_time` or equivalent metadata is available through MCP fetch/update results and is sufficient as the first-version remote baseline for conflict detection.
+- The first version can represent spec content on the Spec page body, plan content on the Plan page body, and context/research as child pages under that Plan row, matching the successful spike and example database shape.
+- Missing safe additive Notion schema pieces can be proposed by doctor, but agents should prompt the user before applying those changes.
+- Live Notion integration does not need to run in default CI until a deterministic MCP fixture or fake can be introduced.
+
+## Rehydration cues
+
+To rehydrate this plan, read `.spektacular/specs/20260509154708-notion-artifact-sync.md`, then read config, init, spec command, plan command, implement command, workflow, store, and step strategy files listed above. Re-run the Notion MCP fetch against the Product Engineering Home page if schema details need to be refreshed. Re-check the prior spec ID prefix PR before changing identifier behavior.

--- a/.spektacular/plans/spec-id-prefix-method/context.md
+++ b/.spektacular/plans/spec-id-prefix-method/context.md
@@ -1,0 +1,167 @@
+# Context: spec-id-prefix-method
+
+## Current State Analysis
+
+- `cmd/spec.go:19` defines `nameRegexp` as lowercase alphanumeric plus hyphen/underscore. It currently validates only the requested spec name, not an external identifier.
+- `cmd/spec.go:136-197` owns `spec new`: it reports schema, parses `--data`, validates `name`, loads config, removes the shared state file for non-dry-run creation, creates a workflow with `store.NewFileStore(dataDir)`, and sets workflow data key `name` to the parsed input name.
+- `cmd/spec.go:137-148` reports a schema with only `name` as input, so external callers cannot discover an `id` field yet.
+- `cmd/spec.go:176-187` removes state before workflow creation and then sets `name` directly from input. New validation must happen before state removal so validation failures do not clobber active state.
+- `cmd/spec.go:259-292` builds status paths from the workflow data `name`, so putting the canonical name in state makes status output naturally follow the new naming behavior.
+- `internal/steps/spec/steps.go:11-14` builds the store-relative spec path as `specs/<name>.md`.
+- `internal/steps/spec/steps.go:63-80` writes the initial scaffold for `new()` using the workflow data `name`; it should not need to know which identifier method was used.
+- `internal/steps/spec/strategy.go:14-18` reports `spec_path` and `spec_name` from the workflow name. This supports resolving the final name before workflow start.
+- `internal/config/config.go:18-32` defines the top-level config and defaults. `FromYAMLFile` unmarshals into `NewDefault()`, so missing fields can inherit defaults.
+- `internal/config/config_test.go:11-49` covers default values, env expansion, missing-file errors, and round-trip behavior.
+- `cmd/root.go:30-42` loads `.spektacular/config.yaml`, returning defaults when the file is absent and errors when it is invalid.
+- `internal/project/init.go:38-44` writes default config only if it does not exist. Updating `NewDefault()` updates newly initialized projects.
+- `cmd/init.go:36-44` loads, mutates, and writes config during `init`, so new fields must survive re-init paths.
+- `internal/store/store.go:48-55` rejects paths that escape the store root; identifier validation should still reject unsafe characters before path construction.
+- `internal/store/store.go:112-119` checks path existence, which is enough for timestamp, counter, and explicit-id collision detection.
+- `internal/steps/spec/steps_test.go:112-122` verifies that the spec `new()` step writes a scaffold at `SpecFilePath(name)`.
+- `cmd/implement_test.go:38-51` shows the command-test pattern for resetting `rootCmd` output, error, and args between invocations.
+- `templates/skills/workflows/spek-new/SKILL.md:8-31` says the workflow writes `.spektacular/specs/<name>.md`; this needs to change because the returned `spec_name` can now include a generated or supplied prefix.
+- `.agents/skills/spek-new/SKILL.md:8-31` is tracked in this repository and currently has the same stale assumption as the template, so it should be updated directly as part of this plan.
+- `README.md:130-145` has a config section that is already stale relative to the current config struct, but it is the user-facing place to document the new spec id method.
+
+## Per-Phase Technical Notes
+
+### Phase 1.1: Configurable ID Methods
+
+- `internal/config/config.go:13-23` - add a new nested spec config type with `id_method` and `counter` YAML fields, then add that field to `Config`.
+- `internal/config/config.go:25-33` - set `NewDefault().Spec.IDMethod` to `timestamp` and `NewDefault().Spec.Counter` to `0`.
+- `internal/config/config.go:35-49` - no loader rewrite is expected; because loading unmarshals into defaults, existing config files should inherit `timestamp` when `spec.id_method` is omitted. Add tests to prove this rather than changing the loader shape.
+- `internal/config/config_test.go:11-16` - extend default assertions to include `cfg.Spec.IDMethod == "timestamp"`.
+- `internal/config/config_test.go:18-30` - add a test loading YAML with only `command` to prove missing `spec` config defaults to timestamp.
+- `internal/config/config_test.go:37-49` - extend round-trip assertions to include `Spec.IDMethod` and `Spec.Counter`.
+- `internal/project/init.go:38-44` - no direct edit should be needed beyond the config default, but verify the generated config file includes `spec.id_method`.
+- `cmd/init.go:36-44` and `cmd/init_test.go:147-168` - verify re-init with a config file that lacks `spec` still writes a valid config and preserves custom command behavior.
+
+**Complexity**: Low
+**Token estimate**: ~6k
+**Agent strategy**: Single agent, sequential execution.
+
+### Phase 1.2: Identifier Resolution Rules
+
+- `internal/steps/spec/steps.go:11-14` - keep `SpecFilePath(name)` unchanged and treat `name` as already canonical.
+- `internal/steps/spec/` - create a new resolver source file in the spec steps package so `cmd/spec.go` can call it through the existing spec import. Suggested contract shape:
+
+```go
+request := struct {
+    Name   string
+    ID     string
+    Method string
+    Counter int
+    Store  store.Store
+    Now    func() time.Time
+}{}
+
+result := struct {
+    Name    string
+    Counter int
+}{}
+```
+
+- `internal/steps/spec/` - in the new resolver source file, define method constants for `timestamp`, `counter`, and `external`; treat an empty method as timestamp.
+- `internal/steps/spec/` - add a normalization/validation helper shared by requested names and explicit IDs. It must reject empty raw values, leading or trailing whitespace (`raw != strings.TrimSpace(raw)`), path separators, control characters, and values that normalize to empty. It must lower-case ASCII input, preserve alphanumeric characters and underscores, and replace accepted separator/special characters such as `.`, `@`, `-`, and internal whitespace runs with a single `-`.
+- `internal/steps/spec/` - compose final names with a hyphen separator: `<prefix>-<name>`.
+- `internal/steps/spec/` - timestamp mode should use `req.Now().UTC().Format("20060102150405")`; default `Now` to `time.Now` if omitted. Before returning, check whether `SpecFilePath(candidate)` exists; if it does, add one second and retry until the candidate is unused.
+- `internal/steps/spec/` - counter mode should start from `req.Counter + 1`, format as six digits, and check for collisions. If the target exists because the stored counter is stale, keep incrementing until an unused target is found and return that value as the new current counter.
+- `internal/steps/spec/` - explicit id mode should also check the target path and fail on collision rather than overwrite an existing spec.
+- `internal/store/store.go:112-119` - use `Exists(SpecFilePath(candidate))` for timestamp, counter, and explicit-id collision detection.
+- `internal/steps/spec/` - create a new resolver test file with deterministic tests for default timestamp, timestamp collision bumping, explicit timestamp method, counter from configured value, stale counter collision bumping, explicit id override with normalization, external missing id, external with normalized id, unknown method, leading/trailing whitespace rejection, slash/control-character rejection, and nil store in generated modes.
+
+**Complexity**: Medium
+**Token estimate**: ~12k
+**Agent strategy**: Single agent, sequential execution; tests should be written alongside the resolver because the behavior is compact and state-free.
+
+### Phase 2.1: Native Spec Creation Wiring
+
+- `cmd/spec.go:21-39` - `schemaProp` already supports type, enum, pattern, and maxLength. Reuse it to describe optional `id` in the `spec new --schema` input.
+- `cmd/spec.go:136-148` - update schema properties to include `id` with a filename-safe pattern and max length. Keep `Required` as only `name`.
+- `cmd/spec.go:151-159` - extend the anonymous input struct with `ID string `json:"id"``.
+- `cmd/spec.go:163-165` - replace the direct requested-name regex check with the shared normalization/validation helper so names like `Team.Alpha` normalize to `team-alpha` while names with leading/trailing whitespace fail.
+- `cmd/root.go:30-42` - add a helper that returns the config path, or otherwise expose the path to `runSpecNew`, because counter mode must write the updated `spec.counter` value back to `.spektacular/config.yaml`.
+- `cmd/spec.go:167-186` - create the store before workflow creation, resolve the canonical name with config and input id, persist any counter update when not dry-run, then remove state only after resolution and counter persistence succeed.
+- `cmd/spec.go:183-187` - pass the same store instance to `workflow.New` and set workflow data `name` to the resolved canonical name, not the requested suffix.
+- `cmd/spec.go:193-195` - keep `output.WriteError` behavior for workflow errors. Resolver/config validation errors can return directly, matching current validation style.
+- `internal/steps/spec/steps.go:71-77` - no method branching should be added here. The step writes the scaffold using the canonical name it receives.
+- `internal/steps/spec/strategy.go:14-18` - no direct change expected; verify returned `spec_path` and `spec_name` reflect the canonical name.
+- `cmd/spec.go:176-180` - preserve dry-run behavior. Dry-run should resolve and report the canonical name but avoid removing state, writing a spec file, or updating the persisted counter.
+
+**Complexity**: Medium
+**Token estimate**: ~10k
+**Agent strategy**: Single agent, sequential execution because command state ordering and resolver use are tightly coupled.
+
+### Phase 2.2: Public Command Contract Coverage
+
+- `cmd/` - create a new spec command test file rather than overloading `internal/steps/spec` tests. Mirror the `setupImplementCmd` pattern from `cmd/implement_test.go:38-51`.
+- `cmd/` - add helper setup that creates `.spektacular/`, writes optional config YAML, executes `rootCmd`, and decodes JSON output.
+- `cmd/` - test default creation creates exactly one spec file whose basename matches `^\d{14}-billing-export\.md$`, returns `step == "overview"`, and returns matching normalized `spec_name` and `spec_path`.
+- `cmd/` - test timestamp collision by pre-creating the first timestamp target and asserting creation bumps to the next second.
+- `cmd/` - test counter mode with config `spec.id_method: counter` and `spec.counter: 7` produces `000008-billing-export.md` and persists `spec.counter: 8`.
+- `cmd/` - test stale counter collision by pre-creating `000008-billing-export.md` and asserting the command creates `000009-billing-export.md` and persists `9`.
+- `cmd/` - test explicit `id` input like `EXT.User@123` creates `ext-user-123-billing-export.md` even when config is timestamp or counter.
+- `cmd/` - test external mode without id returns an error and leaves both the specs directory and shared state file absent or unchanged.
+- `cmd/` - test external mode with id succeeds.
+- `cmd/` - test `spec new --schema` contains `"id"` and keeps `"name"` required.
+- `cmd/` - test unsafe and untrimmed name/id values fail before file creation.
+- `internal/steps/spec/steps_test.go:112-122` - keep the existing scaffold test as-is or update only if helper names move; it should continue to prove `new()` writes `SpecFilePath(name)`.
+
+**Complexity**: Medium
+**Token estimate**: ~14k
+**Agent strategy**: Single agent. Command tests share global `rootCmd`; keep them sequential and isolated with cleanup.
+
+### Phase 3.1: Generated Guidance And Documentation
+
+- `templates/skills/workflows/spek-new/SKILL.md:8` - update wording so it says the workflow produces the spec file returned by `spec_path`, not always `.spektacular/specs/<name>.md`.
+- `templates/skills/workflows/spek-new/SKILL.md:25-31` - add a short note that external callers may pass `id` in the JSON payload and that agents should use the returned `spec_name` for later plan workflows.
+- `.agents/skills/spek-new/SKILL.md:8-31` - update the tracked local skill alongside the template so Codex in this repository sees the new behavior immediately.
+- `README.md:130-145` - replace or augment the stale config example with a minimal current config example that includes `spec.id_method: timestamp` and documents valid values `timestamp`, `counter`, and `external`.
+- `README.md` near spec creation usage - document `spec new --data '{"name":"billing-export","id":"EXT-123"}'` as the external-id override example if the surrounding command reference exists.
+- `CHANGELOG.md` - if implementation conventions require changelog updates for user-facing CLI behavior, add a concise entry describing timestamp default prefixes and optional external IDs.
+
+**Complexity**: Low
+**Token estimate**: ~7k
+**Agent strategy**: Single agent, sequential execution.
+
+### Phase 3.2: Final Regression Pass
+
+- `internal/config/config_test.go` - run the config package tests after config changes.
+- `internal/steps/spec/` package tests and `internal/steps/spec/steps_test.go` - run the spec package tests after resolver and workflow checks.
+- `cmd/` package tests - run command tests after command wiring and schema changes.
+- `cmd/init_test.go` and `internal/project/init_test.go` - run init tests after config defaults and docs/guidance changes.
+- Full repository test suite - run once after focused tests pass.
+- Manual smoke path - from a temp project or with dry-run where appropriate, verify a spec creation returns a prefixed `spec_name` and that the next plan workflow can target that returned name.
+
+**Complexity**: Low
+**Token estimate**: ~5k
+**Agent strategy**: Single agent. Parallel test execution is handled by Go; no multi-agent split is needed.
+
+## Testing Strategy
+
+Use three layers of coverage. First, pure resolver tests should prove naming rules with no Cobra or workflow involvement. Second, command tests should prove external behavior through JSON input, schema output, filesystem writes, and state side effects. Third, existing workflow, config, init, and store tests should serve as regression coverage so the feature does not accidentally change unrelated workflow behavior.
+
+The most important cases are timestamp default behavior, timestamp collision bumping, explicit id normalization, counter incrementing and persistence, stale counter collision handling, external mode requiring id, unsafe or untrimmed input rejection, existing config compatibility, and schema discoverability.
+
+## Project References
+
+- Specification: `.spektacular/specs/spec-id-prefix-method.md`
+- Plan namespace from workflow: `spec-id-prefix-method`
+- Derived feature slug from existing plans: `0020-spec-id-prefix-method`
+- Metadata: created `2026-05-08T17:49:29Z`, commit `a3108b2`, branch `main`, repository `https://github.com/gregoryhunt/spektacular.git`
+
+## Token Management Strategy
+
+| Tier | Token Budget | Agent Strategy |
+|------|-------------|----------------|
+| Low | ~10k | Single agent, sequential |
+| Medium | ~25k | Single agent with focused file reads; optional split only between docs and tests |
+| High | ~50k+ | Not expected for this feature |
+
+## Migration Notes
+
+Existing config files remain valid because the new fields are optional and default to timestamp plus counter zero. Existing specification files are not renamed. The default behavior for new spec creation changes from unprefixed names to timestamp-prefixed names, and accepted names/ids are normalized, so callers that previously assumed the requested name was the final filename must use the returned `spec_name` or `spec_path`.
+
+## Performance Considerations
+
+Timestamp and explicit-id modes are constant-time unless they encounter a collision, in which case they perform repeated existence checks until an unused target is found or the explicit-id collision fails. Counter mode uses the persisted counter and only performs existence checks while avoiding stale-counter collisions, so it no longer needs to scan all spec filenames. If a project accumulates enough collisions to make repeated checks expensive, that indicates the counter or timestamp source is stale and should be investigated separately.

--- a/.spektacular/plans/spec-id-prefix-method/plan.md
+++ b/.spektacular/plans/spec-id-prefix-method/plan.md
@@ -1,0 +1,281 @@
+# Plan: spec-id-prefix-method
+
+<!-- Metadata -->
+<!-- Created: 2026-05-08T17:49:29Z -->
+<!-- Commit: a3108b2 -->
+<!-- Branch: main -->
+<!-- Repository: https://github.com/gregoryhunt/spektacular.git -->
+<!-- Feature Slug: 0020-spec-id-prefix-method -->
+
+## Overview
+
+Specification creation will produce prefixed, chronologically sortable names by default while still allowing teams to choose counter-based names or accept identifiers from external systems. This makes new specs easier to organize and safer to automate without changing the authoring workflow users already follow.
+
+## Architecture & Design Decisions
+
+The chosen design resolves the final specification name before the spec workflow is created. The creation request still starts with a human-readable name, but `spec new` converts that request into the canonical workflow name by applying an explicit identifier, a timestamp prefix, or the next counter prefix. The rest of the workflow continues to operate on one name, so the returned `spec_name`, saved state, status output, scaffold title, and file path all agree.
+
+Identifier generation is owned by a small resolver with three supported methods: `timestamp`, `counter`, and `external`. The default is `timestamp`, explicit `id` input overrides generated methods, and `external` mode requires that the caller provide `id`. Timestamp prefixes use UTC and lexicographic formatting with second-bump collision handling; counter prefixes use a zero-padded numeric prefix backed by a persisted project counter.
+
+Configuration stays additive through a nested spec config block, so existing config files remain valid and new projects expose the default method and counter value. The command schema is expanded to document optional `id` input for agents and external callers. Rejected options are captured in [research.md#alternatives-considered-and-rejected](./research.md#alternatives-considered-and-rejected), especially the alternatives of doing this in skills or mutating only the file path inside the workflow.
+
+## Component Breakdown
+
+- **Spec identifier resolver** owns method validation, normalization, prefix generation, collision checks, explicit identifier validation, and final canonical name composition. It is the only component that needs to know how timestamp, counter, and external identifier modes differ.
+- **Project configuration** owns the optional default method and current counter value for spec identifiers. It provides defaults when fields are omitted and persists counter progress for counter mode.
+- **Spec creation command adapter** owns JSON input parsing, schema reporting, loading configuration, invoking the resolver, and starting the workflow with the canonical name.
+- **Existing spec workflow** continues to own scaffold rendering, step instructions, state persistence, and final spec file writes. It receives the canonical name and does not branch on identifier method.
+- **Guidance and tests** keep installed skills, docs, and regression coverage aligned with the new creation contract so agents know to trust the returned spec path and spec name.
+
+## Data Structures & Interfaces
+
+The config contract gains a nested spec block and the creation input gains an optional `id` value:
+
+```go
+type Config struct {
+    Command string      `yaml:"command"`
+    Agent   string      `yaml:"agent"`
+    Debug   DebugConfig `yaml:"debug"`
+    Spec    struct {
+        IDMethod string `yaml:"id_method"`
+        Counter  int    `yaml:"counter"`
+    } `yaml:"spec"`
+}
+```
+
+The resolver contract accepts the requested name, optional id, configured method, store access for counter mode, and a clock for timestamp mode. It returns the canonical workflow name or a validation error:
+
+```go
+request := struct {
+    Name   string
+    ID     string
+    Method string
+    Counter int
+    Store  store.Store
+    Now    func() time.Time
+}{}
+
+result := struct {
+    Name    string
+    Counter int
+}{}
+```
+
+Supported method values are `timestamp`, `counter`, and `external`. An empty method is equivalent to `timestamp`. Names and identifiers are normalized by lowercasing and replacing accepted separator characters with `-`; leading or trailing whitespace is a validation error, not something the system trims.
+
+## Implementation Detail
+
+The implementation introduces one focused naming boundary before workflow state is created. Command parsing validates the requested suffix name, loads configuration, creates the project store, resolves the canonical spec name, and only then removes or writes workflow state. This ordering ensures configuration errors, invalid identifiers, or missing external identifiers fail without creating a spec file or clobbering active state.
+
+The resolver treats explicit `id` input as a universal override after normalization. Generated methods only run when no id is provided; `external` mode is the opposite contract and errors unless id is provided. Input validation rejects empty values, leading or trailing whitespace, path separators, and control characters, then normalizes accepted values by lowercasing and replacing separators such as `.`, `@`, and internal whitespace with `-`.
+
+Counter generation reads the current project counter from config, increments it, formats it with six digits, and persists the new current value as part of successful counter allocation. Timestamp generation uses UTC seconds in `YYYYMMDDHHMMSS` form so alphabetical order matches creation order; if a timestamp-created filename already exists, the resolver adds one second and checks again until it finds an unused filename. Existing file write behavior remains owned by the workflow and store, but the command must not allow generated or explicit names to overwrite an existing spec.
+
+## Dependencies
+
+- **Cobra command handling** provides the existing subcommand, flag, and schema surfaces; it needs a narrow input/schema update for optional id.
+- **YAML config loading** provides default-backed config parsing; it needs one nested config block and tests for omission/round-trip behavior.
+- **Project file store** provides path traversal protection and existence checks; it is reused for collision detection without API changes.
+- **Spec workflow steps** provide scaffold writing and status/path output; they should continue to receive one canonical name.
+- **Embedded skill templates and README docs** provide user and agent guidance; they need wording updates so generated names and optional ids are visible.
+- **Standard library time and parsing utilities** are sufficient for timestamp formatting, counter parsing, and validation; no new third-party dependency is required.
+
+## Testing Approach
+
+Testing concentrates on the resolver and command boundary because those are the places where behavior changes. Resolver unit tests should use deterministic clocks and temp stores to prove method defaults, timestamp formatting, timestamp collision bumping, counter incrementing from config, explicit id normalization, external mode requirements, and invalid identifiers.
+
+Command-level tests should exercise `spec new` as an external caller sees it: JSON input, schema output, file creation, returned path/name, dry-run behavior, and failure without side effects. Config tests should prove old config files remain valid and new defaults round-trip.
+
+Existing workflow tests remain valuable regression coverage. They should continue to pass with canonical names because the workflow should not need to understand how those names were chosen.
+
+## Milestones & Phases
+
+### Milestone 1: Identifier Rules Are Defined
+
+**What changes**: The project gains a clear, testable contract for how spec identifiers are configured, generated, and validated. This milestone does not change the user-facing creation flow yet; it creates the safe foundation that later phases wire into creation.
+
+#### - [x] Phase 1.1: Configurable ID Methods
+
+Add the optional spec identifier method and current counter value to configuration with timestamp and zero as defaults. Existing config files continue to load without edits, while newly written configs expose the default method and counter clearly. This phase establishes the persistent project preference and counter state before any creation behavior depends on them.
+
+*Technical detail:* [context.md#phase-11-configurable-id-methods](./context.md#phase-11-configurable-id-methods)
+
+**Acceptance criteria**:
+
+- [x] Projects without a spec identifier setting still load with timestamp behavior selected.
+- [x] New or round-tripped config output includes the spec identifier method and current counter without losing existing command, agent, or debug settings.
+- [x] Invalid or unknown method values are rejected when spec creation tries to use them.
+
+#### - [x] Phase 1.2: Identifier Resolution Rules
+
+Add the resolver that turns a requested spec name into the canonical spec name. It normalizes accepted names and ids without trimming, covers timestamp, counter, and external identifier methods, treats a passed id as an override for generated methods, and returns any updated counter value. This phase makes the naming behavior deterministic and isolated before command wiring.
+
+*Technical detail:* [context.md#phase-12-identifier-resolution-rules](./context.md#phase-12-identifier-resolution-rules)
+
+**Acceptance criteria**:
+
+- [x] Timestamp resolution produces a sortable timestamp prefix followed by the requested name.
+- [x] Timestamp resolution bumps by seconds when the initial timestamp target already exists.
+- [x] Counter resolution uses the next persisted counter value and returns the updated current counter.
+- [x] Passed identifiers are normalized, accepted for generated methods, and required for external mode.
+- [x] Unsafe or untrimmed name and identifier values are rejected before any file path is built.
+
+### Milestone 2: Spec Creation Uses Canonical Names
+
+**What changes**: Users and external systems get the new naming behavior through the native spec creation command. The returned spec path, active workflow state, and created file all use the same canonical name.
+
+#### - [x] Phase 2.1: Native Spec Creation Wiring
+
+Wire the resolver into spec creation before workflow state is created. The command accepts optional id input, applies the configured method, persists counter changes when counter mode allocates a value, and starts the existing workflow with the resolved canonical name. Failure cases stop before any spec file or workflow state is written.
+
+*Technical detail:* [context.md#phase-21-native-spec-creation-wiring](./context.md#phase-21-native-spec-creation-wiring)
+
+**Acceptance criteria**:
+
+- [x] Creating a spec without id or config uses a timestamp-prefixed filename.
+- [x] Creating a spec with id uses the normalized id as the prefix regardless of generated method configuration.
+- [x] External mode without id fails clearly and leaves no new spec file behind.
+- [x] Counter mode advances the persisted current counter when creation succeeds.
+- [x] Dry-run creation reports the same canonical name shape without writing files.
+
+#### - [x] Phase 2.2: Public Command Contract Coverage
+
+Add command-level coverage for the behavior external callers rely on. These tests verify the JSON input contract, schema visibility, returned metadata, and filesystem outcomes. This phase catches regressions that pure resolver tests cannot see.
+
+*Technical detail:* [context.md#phase-22-public-command-contract-coverage](./context.md#phase-22-public-command-contract-coverage)
+
+**Acceptance criteria**:
+
+- [x] The creation schema documents both `name` and optional `id`.
+- [x] Timestamp, timestamp collision, counter, explicit id normalization, and external-mode cases are observable through command output.
+- [x] Validation failures do not leave behind a created spec or new workflow state.
+
+### Milestone 3: Guidance And Regression Safety Are Updated
+
+**What changes**: Agents, users, and future maintainers can see and trust the new naming behavior. Documentation and generated guidance explain that callers should use the spec name and path returned by the command.
+
+#### - [x] Phase 3.1: Generated Guidance And Documentation
+
+Update the generated and tracked spec workflow guidance plus user-facing docs to describe prefixed names, normalized optional id input, and the config method. This keeps installed agent instructions aligned with the binary-owned behavior without requiring wrapper logic.
+
+*Technical detail:* [context.md#phase-31-generated-guidance-and-documentation](./context.md#phase-31-generated-guidance-and-documentation)
+
+**Acceptance criteria**:
+
+- [x] Generated spec workflow guidance no longer assumes the requested name is always the final filename.
+- [x] The tracked local `spek-new` skill is updated alongside the template so repository agents see the new behavior immediately.
+- [x] User-facing documentation shows the config method values and optional id input.
+- [x] Documentation tells callers to use returned spec metadata for follow-up workflows.
+
+#### - [x] Phase 3.2: Final Regression Pass
+
+Run the focused package tests and the full test suite after all changes are integrated. This phase verifies the new behavior and checks that existing spec, plan, init, config, and store workflows still operate normally.
+
+*Technical detail:* [context.md#phase-32-final-regression-pass](./context.md#phase-32-final-regression-pass)
+
+**Acceptance criteria**:
+
+- [x] All resolver, config, command, and existing workflow tests pass.
+- [x] A manual spec creation produces a prefixed spec path and a usable next workflow state using the returned normalized `spec_name`.
+- [x] No existing plan or implementation artifact naming behavior changes.
+
+## Open Questions
+
+None.
+
+## Out of Scope
+
+- Renaming or migrating existing specification files is out of scope.
+- Building a direct integration with any specific external system is out of scope.
+- Changing the contents or step order of the specification authoring workflow is out of scope.
+- Applying the same identifier method to plans or implementation artifacts is out of scope.
+- Reformatting legacy unpadded or underscore-separated numeric spec filenames is out of scope.
+- Guaranteeing gapless counter values is out of scope; failed filesystem writes after counter allocation may leave skipped numbers.
+
+## Changelog
+
+### FINAL SUMMARY
+
+Implemented native spec identifier prefixes across configuration, resolver logic, `spec new`, command tests, generated guidance, and user-facing docs. New spec creation now defaults to timestamp prefixes, supports persisted counter prefixes, accepts optional external ids, and requires ids for external mode while returning canonical `spec_name` and `spec_path` for follow-up workflows.
+
+**Total phases**: 6/6 completed
+
+**Notable deviations from the plan**: None
+
+### 2026-05-09 - Phase 1.1: Configurable ID Methods
+
+**What was done**: Added `spec.id_method` and `spec.counter` to project configuration with `timestamp` and `0` defaults. Config loading now validates the configured spec ID method, and init/spec command tests cover old config compatibility, round-tripped output, generated config defaults, and `spec new` rejection for unsupported methods.
+
+**Deviations**: None
+
+**Files changed**:
+- `internal/config/config.go`
+- `internal/config/config_test.go`
+- `internal/project/init_test.go`
+- `cmd/init_test.go`
+- `cmd/spec_test.go`
+
+**Discoveries**: Method validation belongs at config load time for this phase because every command that starts a workflow already loads config first; later resolver wiring can reuse the exported config method constants instead of duplicating strings.
+
+### 2026-05-09 - Phase 1.2: Identifier Resolution Rules
+
+**What was done**: Added a spec identifier resolver that normalizes names and optional ids, supports timestamp, counter, and external modes, checks collisions through the project store, and bumps timestamp seconds or counter values until generated names are unused. The resolver returns the canonical spec name plus the current counter value that command wiring can persist later.
+
+**Deviations**: None
+
+**Files changed**:
+- `internal/steps/spec/identifier.go`
+- `internal/steps/spec/identifier_test.go`
+
+**Discoveries**: Explicit id overrides intentionally leave the returned counter unchanged, so Phase 2.1 can persist `spec.counter` only when counter allocation actually advances it.
+
+### 2026-05-09 - Phase 2.1: Native Spec Creation Wiring
+
+**What was done**: Wired `spec new` through the identifier resolver so new specs use canonical timestamp, counter, or external-id names before workflow state is created. Counter mode now persists the advanced `spec.counter` on successful non-dry-run creation, while dry-run resolves and reports the same canonical name without writing specs, state, or counter updates.
+
+**Deviations**: None
+
+**Files changed**:
+- `cmd/root.go`
+- `cmd/spec.go`
+- `cmd/spec_test.go`
+- `internal/steps/spec/identifier.go`
+
+**Discoveries**: Auxiliary `--stdin` and `--file` workflow data must not be allowed to override the resolved `name`; the command now applies extra workflow data first and then restores the canonical name before starting the workflow.
+
+### 2026-05-09 - Phase 2.2: Public Command Contract Coverage
+
+**What was done**: Expanded command-level tests to cover `spec new --schema`, timestamp defaults, timestamp collision bumping, counter and stale-counter behavior, explicit id normalization, external mode success and failure, dry-run output, and validation failures without spec/state side effects. Added a small injectable clock for `spec new` so timestamp collision behavior is deterministic in tests.
+
+**Deviations**: None
+
+**Files changed**:
+- `cmd/spec.go`
+- `cmd/spec_test.go`
+
+**Discoveries**: Cobra flag values can persist between same-process command tests, so the spec command test helper now resets `schema`, `dry-run`, and input flags around each invocation.
+
+### 2026-05-09 - Phase 3.1: Generated Guidance And Documentation
+
+**What was done**: Updated generated and tracked `spek-new` guidance so agents use returned `spec_name` and `spec_path` instead of assuming the requested name is final. README now documents optional external ids, returned metadata usage, and the `spec.id_method` values; the repo changelog includes the user-facing behavior change.
+
+**Deviations**: None
+
+**Files changed**:
+- `templates/skills/workflows/spek-new/SKILL.md`
+- `.agents/skills/spek-new/SKILL.md`
+- `README.md`
+- `CHANGELOG.md`
+
+**Discoveries**: The README command examples were still using older shorthand commands, so the usage section was updated to the current workflow command shape while documenting the new identifier behavior.
+
+### 2026-05-09 - Phase 3.2: Final Regression Pass
+
+**What was done**: Ran focused regression packages, the full Go test suite, and a manual smoke path in a temp project. The smoke created a timestamp-prefixed spec and then started `plan new` with the returned normalized `spec_name`.
+
+**Deviations**: None
+
+**Files changed**:
+- `.spektacular/plans/spec-id-prefix-method/plan.md`
+
+**Discoveries**: `go run` cannot target this module from outside the module directory in the local environment, so the manual smoke used a temporary built binary instead.

--- a/.spektacular/plans/spec-id-prefix-method/research.md
+++ b/.spektacular/plans/spec-id-prefix-method/research.md
@@ -1,0 +1,96 @@
+# Research: spec-id-prefix-method
+
+## Alternatives considered and rejected
+
+### Option A: Implement prefixes only in installed skills or command wrappers
+
+This would update `spek-new` instructions or agent-specific wrappers to prepend timestamps, counters, or external ids before invoking the binary.
+
+**Rejected**: the specification requires native binary behavior, and wrappers are not the canonical execution surface. Current generated skill guidance invokes the binary with a JSON payload (`templates/skills/workflows/spek-new/SKILL.md:25-31`), while init installs multiple agent surfaces (`cmd/init.go:47-50`). Putting naming rules in wrappers would duplicate behavior across agents and leave external callers of the binary without the feature.
+
+### Option B: Prefix only the file path inside the spec workflow step
+
+This would keep workflow data `name` as the user-supplied name and make the spec `new()` step write a different prefixed path.
+
+**Rejected**: the current workflow uses the same data name for path construction and returned metadata. `SpecFilePath(name)` builds `specs/<name>.md` (`internal/steps/spec/steps.go:11-14`), `new()` writes that path (`internal/steps/spec/steps.go:71-77`), strategy output reports `spec_name` and `spec_path` from the same name (`internal/steps/spec/strategy.go:14-18`), and status reconstructs the path from workflow data (`cmd/spec.go:274-286`). Splitting path identity from workflow identity would make follow-up workflows and status output ambiguous.
+
+### Option C: Add separate command flags for identifier behavior
+
+This would add flags such as `--id` or `--method` beside the existing JSON payload rather than extending `--data`.
+
+**Rejected**: the current command contract is JSON input plus schema introspection. `spec new` reads a JSON object from `--data` (`cmd/spec.go:151-162`) and reports its JSON schema (`cmd/spec.go:136-148`). The local CLI architecture note recommends raw JSON payloads, runtime schema introspection, and strong input validation for agent-facing commands (`.spektacular/knowledge/architecture/cli-design-for-ai-agents.md:11-29`). Adding parallel flags would make the command harder for agents and external systems to discover and validate.
+
+### Option D: Store the counter in workflow state
+
+This would track the current counter in the existing workflow state file.
+
+**Rejected**: the current project uses a shared workflow state file that is truncated on each workflow start (`cmd/spec.go:176-180`, `.spektacular/plans/15_implementation/context.md:11-13`). Putting a project-level counter there risks losing the counter whenever another workflow starts. The chosen persistent location is config, where the identifier method already lives.
+
+### Option E: Derive counter values only from existing filenames
+
+This would scan existing spec filenames and select the next number without storing counter state.
+
+**Rejected**: after timestamp prefixes become the default, filename scanning risks confusing timestamp prefixes with counter prefixes unless the parser becomes more complex. It also makes counter behavior depend on historical files rather than the user's configured current counter. A persisted `spec.counter` value gives counter mode an explicit source of truth while still allowing collision checks to avoid overwrites.
+
+## Chosen approach — evidence
+
+- Resolving the canonical name before workflow creation matches existing workflow design because all downstream path and status output already flows from the workflow data `name` (`cmd/spec.go:183-187`, `cmd/spec.go:274-286`, `internal/steps/spec/strategy.go:14-18`).
+- The spec workflow `new()` step already writes a scaffold using `SpecFilePath(name)` (`internal/steps/spec/steps.go:63-80`), so passing a canonical name lets this behavior remain simple.
+- Config loading already unmarshals into `NewDefault()` (`internal/config/config.go:35-49`), which supports additive optional config fields without breaking older config files.
+- Project init writes the default config from `config.NewDefault()` (`internal/project/init.go:38-44`), so adding the default method and counter there also makes them visible to new projects.
+- The file store already rejects path traversal (`internal/store/store.go:48-55`) and can check candidate paths for collision through `Exists` (`internal/store/store.go:112-119`).
+- The command schema types already support pattern, enum, and max length fields (`cmd/spec.go:21-39`), enough to expose the optional id input without schema machinery changes.
+- `plan new` and `implement new` validate workflow names with the shared `nameRegexp` shape (`cmd/plan.go:89-97`, `cmd/implement.go:93-100`), so spec-created names must be normalized into that compatible shape rather than preserving uppercase or special characters.
+
+## Files examined
+
+- `.spektacular/specs/spec-id-prefix-method.md:1` - source specification for timestamp default, counter mode, explicit id override, config method, and non-goals.
+- `.spektacular/knowledge/architecture/cli-design-for-ai-agents.md:11` - local architecture note favoring JSON payloads and runtime schema introspection for agent-facing CLIs.
+- `.spektacular/knowledge/conventions.md:11` - local conventions call for tests on new functionality and README updates for user-facing changes.
+- `.spektacular/plans/13_agent-cli-improvements/plan.md:34` - prior plan established schema introspection and JSON `--data` as command design.
+- `.spektacular/plans/14_spektacular-store/plan.md:220` - prior plan describes store-backed workflow writes and validates spec file creation through the store.
+- `.spektacular/plans/15_implementation/context.md:11` - prior context confirms spec and plan workflows share `.spektacular/state.json`.
+- `cmd/spec.go:19` - existing requested-name regex is lowercase alphanumeric, hyphen, and underscore.
+- `cmd/spec.go:136` - `runSpecNew` owns schema, input parsing, config loading, state removal, workflow creation, and initial workflow data.
+- `cmd/spec.go:259` - status output derives spec path from the workflow data name.
+- `cmd/plan.go:89` - plan creation currently accepts only lowercase workflow names, so spec names returned from this feature must be normalized for follow-up workflows.
+- `cmd/implement.go:93` - implement creation uses the same workflow-name validation shape as plan creation.
+- `cmd/root.go:30` - config loading returns defaults when `.spektacular/config.yaml` is absent.
+- `cmd/init.go:36` - init loads, mutates, and writes config, so new config fields must survive re-init.
+- `cmd/implement_test.go:38` - command tests reset root command state with a helper pattern that can be reused for spec command tests.
+- `internal/config/config.go:18` - top-level config currently has `Command`, `Agent`, and `Debug`.
+- `internal/config/config.go:25` - defaults are centralized in `NewDefault()`.
+- `internal/config/config_test.go:11` - existing config tests cover default and round-trip behavior.
+- `internal/project/init.go:38` - default config writing happens through `config.NewDefault()`.
+- `internal/project/init_test.go:33` - project init tests confirm config file creation.
+- `internal/steps/spec/steps.go:11` - `SpecFilePath` is the path helper for spec files.
+- `internal/steps/spec/steps.go:63` - spec `new()` writes the scaffold and should continue to receive one canonical name.
+- `internal/steps/spec/steps_test.go:112` - existing test asserts scaffold writing through `SpecFilePath`.
+- `internal/steps/spec/strategy.go:14` - path strategy reports spec path and name from the workflow instance name.
+- `internal/store/store.go:48` - store path resolution rejects paths that escape the root.
+- `internal/store/store.go:112` - store existence checks support collision detection for timestamp, counter, and explicit-id targets.
+- `templates/skills/workflows/spek-new/SKILL.md:8` - generated spec skill currently assumes the requested name is the final filename.
+- `README.md:130` - README has the user-facing config section to update for `spec.id_method`.
+
+## External references
+
+None fetched during this planning pass. The local architecture note at `.spektacular/knowledge/architecture/cli-design-for-ai-agents.md` cites an external CLI design article and was used only for local design principles.
+
+## Prior plans / specs consulted
+
+- `.spektacular/specs/spec-id-prefix-method.md` - defines the required behavior and explicitly excludes existing spec migration, external-system integrations, workflow content changes, and plan/implementation artifact naming.
+- `.spektacular/plans/13_agent-cli-improvements/plan.md` - confirms the project direction for JSON `--data`, schema introspection, dry-run behavior, and agent-facing validation.
+- `.spektacular/plans/14_spektacular-store/plan.md` - confirms spec creation is store-backed and that path traversal protection belongs in the store layer while command/spec validation remains useful.
+- `.spektacular/plans/15_implementation/context.md` - confirms current workflow state is shared and should not be split or migrated for this feature.
+
+## Open assumptions
+
+None. The reviewed gaps have been resolved in the plan: externally supplied-id mode is `external`, timestamp collisions bump by whole seconds, counter mode uses persisted config state, accepted names and ids are normalized without trimming, and tracked/generated skill guidance is updated.
+
+## Rehydration cues
+
+- Re-read `.spektacular/specs/spec-id-prefix-method.md` for the feature contract.
+- Re-read `cmd/spec.go`, `internal/config/config.go`, `internal/steps/spec/steps.go`, `internal/steps/spec/strategy.go`, and `internal/store/store.go` before implementation.
+- Use `rg -n "spec new|SpecFilePath|nameRegexp|config.yaml|id_method|counter|schema" cmd internal templates README.md .spektacular` to rebuild the local map.
+- Use `go run . spec new --schema` after implementation to verify schema visibility.
+- Focus first on resolver tests, then command tests, then full regression.

--- a/.spektacular/specs/20260509154708-notion-artifact-sync.md
+++ b/.spektacular/specs/20260509154708-notion-artifact-sync.md
@@ -1,0 +1,210 @@
+# Feature: 20260509154708-notion-artifact-sync
+
+<!--
+  OVERVIEW
+  A concise 2-3 sentence summary of the feature. Answer three questions:
+    1. What is being built?
+    2. What problem does it solve?
+    3. Who benefits and why does it matter?
+  Avoid implementation details — this should be readable by any stakeholder.
+-->
+## Overview
+
+Spektacular will let teams keep specifications and implementation plans in Notion while still working from a local cache when agents are creating, reviewing, or implementing work. This solves the coordination problem where shared product and planning artifacts live in Notion, but coding agents need local, repeatable files and conflict checks before they edit or implement them. Product, engineering, and agent users benefit because the shared source of truth stays visible in Notion while local work remains fast, recoverable, and safe from accidental overwrites.
+
+
+
+<!--
+  REQUIREMENTS
+  Specific, testable behaviours the feature must deliver.
+  Format: bold title on the checkbox line, detail indented below.
+  Rules:
+    - Use active voice: "Users can...", "The system must..."
+    - Each requirement should be independently verifiable
+    - Focus on WHAT, not HOW — avoid prescribing implementation
+    - Keep each item atomic — one behaviour per line
+-->
+## Requirements
+
+- [ ] **Users can connect Spektacular to existing Notion workspaces**
+      Users can link Spektacular to existing Notion locations for specifications and plans and receive immediate validation that those locations can support the workflow.
+- [ ] **Users can initialize missing Notion workspace structure**
+      Users can ask Spektacular to create the required shared locations when they do not already exist, then use those locations through the same linked workflow.
+- [ ] **The system identifies incompatible Notion setup before work starts**
+      The system reports missing, fixable, and blocking setup issues before creating, syncing, planning, or implementing shared artifacts.
+- [ ] **Notion setup requires stable Notion identifiers**
+      Spektacular-compatible Notion Specs and Plans locations include required auto-increment identifier fields so Notion-backed artifacts have stable external identifiers.
+- [ ] **Users can maintain local working copies of shared artifacts**
+      Users and agents can pull shared specifications and plans into a local cache, work from that cache, and keep those cached files out of committed source changes.
+- [ ] **Users can pull existing Notion artifacts by shared identity**
+      Users and agents can fetch an existing Notion-backed Spek using a Notion URL, Notion page ID, or Spektacular external identifier when another human or agent is picking up work.
+- [ ] **Users can sync local changes back to Notion deliberately**
+      Users and agents can push local artifact changes to Notion only through an explicit sync action or workflow step that confirms the remote artifact is still safe to update.
+- [ ] **The system prevents accidental overwrite of another user's Notion edits**
+      The system detects when a shared artifact changed after the local cache was last refreshed and blocks a normal push until the conflict is resolved.
+- [ ] **The system guides users and agents through merge conflicts**
+      When local and Notion versions diverge, Spektacular presents a merge flow with the local copy, remote copy, and cache baseline so the user or agent can resolve the conflict before retrying sync.
+- [ ] **Workflow steps sync changed artifact cache**
+      After each Notion-backed workflow step changes a specification, plan, context, or research artifact, the system updates the corresponding local cache and sync metadata before returning the next instruction.
+- [ ] **Workflow steps surface conflicts immediately**
+      When a step cannot safely sync because a shared Notion artifact changed remotely, the system returns a clear resolution need to the agent or user instead of continuing as though the step succeeded.
+- [ ] **Implementation workflows can start from Notion-backed plans**
+      When a plan is stored in Notion, the implementation workflow can ensure the local cache is available and current enough before it begins work.
+- [ ] **Shared artifact relationships stay visible in Notion**
+      Specifications and plans created or synced through Spektacular remain linked in Notion so humans can navigate between the related artifacts.
+- [ ] **Notion-backed specifications use external identifiers**
+      When Notion artifacts are enabled, specification creation uses an externally supplied identifier from the Notion artifact rather than generating a timestamp or counter identifier locally.
+- [ ] **Agent skills explain the Notion artifact flow**
+      Because most users run Spektacular through agent skills, installed and embedded skills explain how to use Notion MCP, how to sync cache changes, and how to stop for merge resolution when Notion mode is enabled.
+
+
+<!--
+  CONSTRAINTS
+  Hard boundaries the solution must operate within. These are non-negotiable.
+  Examples:
+    - Must integrate with the existing authentication system
+    - Cannot introduce breaking changes to the public API
+    - Must support the current minimum supported runtime versions
+  Leave blank if there are no constraints.
+-->
+## Constraints
+
+- Notion-backed artifact support must not remove or break the existing local filesystem artifact workflow.
+- Local cache files for Notion-backed specs and plans must not be committed to source control by default.
+- Linking existing Notion databases must not silently rename, delete, or change incompatible existing properties.
+- Notion schema repair may only apply safe additive changes automatically, such as adding missing compatible properties or missing select options.
+- Notion schema repair must present the proposed safe additive changes to the user or agent before applying them, with an explicit approval path for non-interactive agent runs.
+- Specs and Plans databases must each include a required Notion auto-increment identifier field.
+- Notion-backed spec creation must use an externally supplied Notion-derived identifier and must not fall back to local timestamp or counter generation.
+- Workflow commands must not overwrite a shared Notion artifact when the remote artifact has changed since the local cache was last refreshed.
+- Notion-backed workflow steps that modify artifacts must either complete local cache sync and metadata updates or stop with an explicit resolution requirement.
+- When a project is initialized directly for Notion artifacts, Spektacular must not create the local-only `.spektacular/specs` or `.spektacular/plans` artifact folders; it should create only the project metadata, state/config, knowledge content, and ignored Notion cache paths needed for that mode.
+- Knowledge-base content and implementation artifacts are outside the first Notion-backed artifact scope.
+
+
+<!--
+  ACCEPTANCE CRITERIA
+  The specific, binary conditions that define "done".
+  Format: bold title on the checkbox line, verifiable detail indented below.
+  Each criterion must be:
+    - Independently verifiable (pass/fail, not subjective)
+    - Traceable back to a requirement above
+    - Testable by someone who didn't write the code
+-->
+## Acceptance Criteria
+
+- [ ] **Link validates existing Notion locations**
+      Given existing compatible Notion specification and plan locations, when the user links them to Spektacular, the command succeeds, writes the linked configuration, and reports that validation passed.
+- [ ] **Link refuses incompatible locations**
+      Given linked Notion locations with missing required fields or incompatible field types, when the user links them to Spektacular, the command reports each issue and does not leave the project configured as ready unless validation passes.
+- [ ] **Doctor reports fixable and blocking setup issues**
+      Given linked Notion locations with a mix of missing safe-to-add fields and incompatible fields, when the user runs the validation command, the output separates fixable issues from blocking issues.
+- [ ] **Doctor apply adds safe missing setup**
+      Given linked Notion locations missing only safe-to-add fields or options, when the user runs the apply command, the shared Notion locations are updated and a subsequent validation command passes.
+- [ ] **Doctor apply prompts before repair**
+      Given the validation command identifies safe additive repairs, when the user or agent asks to apply them, the command reports the proposed changes and requires explicit approval before changing Notion.
+- [ ] **Init creates missing shared locations**
+      Given a Notion parent page without Spektacular-compatible locations, when the user runs initialization for Notion artifacts, Spektacular creates the required specification and plan locations, validates them, and records their identifiers in the project configuration.
+- [ ] **Notion schema requires auto-increment IDs**
+      Given linked Notion locations do not include the required Spec ID or Plan ID auto-increment fields, when validation runs, the command reports the missing identifier fields as setup issues.
+- [ ] **Notion mode omits local artifact folders**
+      Given a project is initialized directly for Notion artifacts, when initialization completes, local-only spec and plan artifact folders are not created and the ignored Notion cache location is ready for use.
+- [ ] **Notion mode requires external spec identifiers**
+      Given Notion artifacts are configured, when a new specification is created, the resulting Spektacular spec name is based on the external Notion identifier and not on the timestamp or counter methods.
+- [ ] **Spec creation produces a Notion artifact and local cache**
+      Given Notion artifacts are configured, when the user starts a new specification, a new shared specification appears in Notion and the local cache contains the matching editable copy.
+- [ ] **Plan creation links back to the specification**
+      Given a Notion-backed specification, when the user creates a plan for it, a shared plan appears in Notion, it is linked to the specification, and the local cache contains the plan, context, and research working copies.
+- [ ] **Pull refreshes local cache**
+      Given a shared artifact changed in Notion, when the user pulls it locally, the cached file reflects the latest Notion content and the sync metadata records the remote version that was pulled.
+- [ ] **Pull can locate existing work**
+      Given a user or agent has a Notion URL, Notion page ID, or Spektacular external identifier for an existing Notion-backed Spek, when they pull it, the command locates the artifact, records the Notion identity in local state or manifest metadata, and writes the cache.
+- [ ] **Push blocks stale local changes**
+      Given the local cache was based on an older remote version and the Notion artifact has changed since then, when the user tries to push local changes, the command fails with a conflict message and leaves the Notion artifact unchanged.
+- [ ] **Merge flow resolves stale pushes**
+      Given a push is blocked by a stale remote version, when the user or agent completes the merge flow and explicitly retries sync, the command updates Notion only with the resolved content and records the new remote version.
+- [ ] **Step completion syncs changed artifacts**
+      Given a Notion-backed workflow step writes or updates a specification, plan, context, or research artifact, when the step completes successfully, the local cache file and sync manifest reflect the same content and remote version returned by Notion.
+- [ ] **Step conflict pauses the workflow**
+      Given a Notion-backed workflow step detects that a remote artifact changed after the local cache was pulled, when the step attempts to sync, the step returns a conflict or resolution-required response and does not advance to the next workflow instruction.
+- [ ] **Implementation startup refreshes Notion-backed plans**
+      Given implementation starts from a Notion-backed plan, when the user starts the implementation workflow, Spektacular ensures the plan, context, and research cache files exist and either confirms they are current or reports the action needed before implementation can continue.
+- [ ] **Agent skills teach the enabled Notion flow**
+      Given Spektacular is initialized for an agent and Notion artifacts are configured, when the agent uses the installed Spek skills, the instructions explain Notion MCP setup, pull, sync, merge resolution, and the external ID requirement.
+
+
+<!--
+  TECHNICAL APPROACH
+  High-level technical direction to guide the planning agent. Include:
+    - Key architectural decisions already made
+    - Preferred patterns or technologies if known
+    - Integration points with existing systems
+    - Known risks or areas of uncertainty
+  Leave blank if you want the planner to propose the approach.
+-->
+## Technical Approach
+
+Use Notion as the shared source of truth and a local cache as the working copy. Keep `.spektacular/config.yaml` and `.spektacular/state.json` local, but store Notion-backed markdown snapshots under an ignored cache path such as `.spektacular/cache/notion/specs/<spec-name>.md` and `.spektacular/cache/notion/plans/<plan-name>/{plan.md,context.md,research.md}`. This avoids mixing synced cache files with the existing local-only `.spektacular/specs` and `.spektacular/plans` directories.
+
+Do not add direct Notion API calls to the binary in the first version. The binary should own configuration, workflow state, cache metadata, validation rules, and CLI instructions; agents should perform Notion MCP page/database operations when the CLI tells them to. Commands such as `notion init`, `notion link`, and `notion doctor --apply` should emit structured MCP work requests, validate the returned snapshots, and write local config or state only after the requested MCP work is complete. This keeps authentication and workspace access in the MCP layer while still allowing the CLI to enforce deterministic workflow and conflict behavior.
+
+Add Notion artifact configuration under `artifacts`, with `backend: local|notion`, `cache_dir`, and a `notion` block containing the base page URL plus Specs and Plans data source URLs. There is no managed/linked mode distinction: Spektacular always operates against linked Notion databases, whether those databases already existed or were created by `spektacular notion init`.
+
+Introduce Notion setup commands around one shared schema validator. `spektacular notion init --parent <page-url>` guides the agent through creating missing Specs and Plans databases, validates them, applies safe additive setup to databases it just created, and writes config only after validation passes. `spektacular notion link --specs <data-source-url> --plans <data-source-url>` validates existing databases before writing config. `spektacular notion doctor` reports schema status, and `spektacular notion doctor --apply` proposes safe additive fixes, prompts the user or agent for approval, then guides the approved MCP updates.
+
+The required Notion schema should match the example database shape used in the MCP spike. Specs need Name, Status, Approval, Spec ID as a Notion auto-increment identifier, and a relation to Plans. Plans need Name, Status, Approval, Plan ID as a Notion auto-increment identifier, and a relation to Specs. Tags, Author, Reviewers, Linear Issues, and related product fields are useful when present but should not be required for the first version unless needed by the example database relationship model.
+
+Spec content should be stored in the Notion Spec database page body, matching the page-body model available in the example workspace. Plan content should be stored in the Notion Plan database page body, and Context and Research should be child pages under the Plan row. The MCP spike confirmed that creating a Plan with its Spec relation set to the Spec page URL automatically populated the reverse Spec-to-Plan relation.
+
+Notion-backed specs must use the existing external ID path from the spec identifier work. On creation, the Notion Spec page should be created first so its required Spec ID auto-increment value can be used as the canonical external identifier, then `spec new` should receive that identifier through the `id` input and run with external ID behavior. This avoids local timestamp or counter IDs diverging from the shared Notion artifact identity.
+
+Maintain a cache manifest with each artifact's remote URL, Notion page ID, Notion data source ID, Spektacular external ID, last remote edit timestamp, local checksum, and local path. Workflow state may also record the active Notion page IDs and external IDs so another user or agent can pull existing work by URL, page ID, or external ID. Pull reads the Notion page content into the cache and records the remote version. Push fetches the remote version first; if the remote timestamp differs from the manifest value, the push enters a merge flow instead of overwriting Notion.
+
+Every Notion-backed workflow step should update and sync artifacts using the same user-visible cadence as the existing filesystem workflow. Agents should keep using local markdown cache files and the same Spek state-machine flow; when the filesystem workflow would create, update, or finalize an artifact, Notion mode should update the cache and sync the corresponding Notion page before returning the next instruction. If the sync layer detects that the remote artifact changed since the cache baseline, the workflow step should not advance; it should engage the user or agent in a merge flow that presents the baseline, local version, and remote version, then retries sync only after explicit resolution.
+
+Implementation startup should call the same sync layer before the workflow begins. For Notion-backed plans, `implement new` should verify the plan, context, and research cache entries exist and are not stale, pulling or reporting the required pull action before the implementation agent reads local files.
+
+Because most users interact with Spektacular through agent skills, Notion mode must be explicit in the embedded and installed skills. Skills should tell agents when Notion mode is enabled, what MCP calls are expected, how to pull existing work, how to keep cache files in sync, how to use the required external identifiers, and when to stop and ask the user during doctor repair or merge resolution.
+
+
+<!--
+  SUCCESS METRICS
+  How you will know the feature is working well after delivery. Be specific:
+    - Quantitative: "p99 latency < 200ms", "error rate < 0.1%"
+    - Behavioural: "users complete the flow without support intervention"
+  Leave blank if not applicable.
+-->
+## Success Metrics
+
+- A compatible existing Notion workspace can be linked, validated, and used to create a spec and plan without manual database edits.
+- A missing Notion workspace structure can be initialized from a parent page and pass validation immediately after setup.
+- Compatible Notion Specs and Plans databases include required Spec ID and Plan ID auto-increment identifier fields.
+- Normal sync operations never overwrite a remote Notion edit that happened after the local cache was last pulled.
+- A stale local cache reliably enters a merge flow rather than offering only a generic failure.
+- Each successful Notion-backed workflow step leaves the local cache and manifest aligned with the latest remote version of every artifact changed by that step.
+- Conflict or resolution-required responses appear at the step where the unsafe sync is detected, not later during planning or implementation.
+- Notion-backed implementation startup either prepares a complete local plan/context/research cache or exits with a clear corrective action.
+- The existing local filesystem workflow continues to pass its current CLI and Harbor validation after Notion support is added.
+- Agent skills are sufficient for an agent to run the Notion-backed flow without reading source code.
+- Setup validation errors are actionable enough that a user can distinguish safe automatic fixes from blocking schema incompatibilities without reading source code.
+
+
+<!--
+  NON-GOALS
+  Explicitly state what this spec does NOT cover. This is as important as
+  the requirements — it prevents scope creep and sets clear expectations.
+  Examples:
+    - "Mobile support is out of scope (tracked in #456)"
+    - "Internationalisation will be addressed in a follow-up spec"
+  Leave blank if there are no explicit exclusions to call out.
+-->
+## Non-Goals
+
+- Syncing `.spektacular/knowledge` content to or from Notion is out of scope.
+- Syncing implementation artifacts, generated code, test output, or build artifacts to Notion is out of scope.
+- Adding direct Notion API authentication and HTTP clients inside the binary is out of scope for the first version.
+- Automatically merging conflicting local and remote edits is out of scope; the first version should detect and block conflicts.
+- Deleting, renaming, or changing incompatible existing Notion database properties automatically is out of scope.
+- Replacing the current local-only filesystem workflow is out of scope.
+- Building a general-purpose Notion database migration framework is out of scope.
+- Supporting arbitrary Notion workspace shapes beyond the required Specs and Plans databases is out of scope.

--- a/.spektacular/specs/spec-id-prefix-method.md
+++ b/.spektacular/specs/spec-id-prefix-method.md
@@ -1,0 +1,149 @@
+# Feature: spec-id-prefix-method
+
+<!--
+  OVERVIEW
+  A concise 2-3 sentence summary of the feature. Answer three questions:
+    1. What is being built?
+    2. What problem does it solve?
+    3. Who benefits and why does it matter?
+  Avoid implementation details — this should be readable by any stakeholder.
+-->
+## Overview
+
+Specification creation should generate stable, migration-style identifiers by default so new specs sort chronologically and avoid ambiguous naming collisions. Teams can choose timestamp-based or counter-based generated prefixes, while external systems can supply their own normalized identifier when they create a spec, making automated integrations predictable without removing manual flexibility.
+
+
+<!--
+  REQUIREMENTS
+  Specific, testable behaviours the feature must deliver.
+  Format: bold title on the checkbox line, detail indented below.
+  Rules:
+    - Use active voice: "Users can...", "The system must..."
+    - Each requirement should be independently verifiable
+    - Focus on WHAT, not HOW — avoid prescribing implementation
+    - Keep each item atomic — one behaviour per line
+-->
+## Requirements
+
+- [ ] **Timestamp prefixes by default**
+      The system must generate timestamp-style prefixes for new specifications when no other identifier method is configured or requested.
+- [ ] **Counter prefixes available**
+      Users can choose counter-style generated prefixes for new specifications.
+- [ ] **External identifiers accepted**
+      Users and external systems can pass an explicit identifier during specification creation, and the system must use the normalized value instead of generating one.
+- [ ] **Input normalization and validation**
+      The system must normalize accepted spec names and identifiers into valid workflow names without silently trimming leading or trailing whitespace.
+- [ ] **Configurable identifier method**
+      Users can set a default identifier method in configuration so future specification creation uses that method unless an explicit identifier is provided.
+- [ ] **Explicit identifiers override method defaults**
+      The system must accept a passed identifier regardless of the configured identifier method.
+- [ ] **Required identifiers for external mode**
+      When configuration selects the externally supplied identifier method, specification creation must require an explicit identifier value.
+- [ ] **Native creation behavior**
+      Identifier selection and validation must be available through the standard specification creation workflow without requiring a separate wrapper or integration script.
+
+
+<!--
+  CONSTRAINTS
+  Hard boundaries the solution must operate within. These are non-negotiable.
+  Examples:
+    - Must integrate with the existing authentication system
+    - Cannot introduce breaking changes to the public API
+    - Must support the current minimum supported runtime versions
+  Leave blank if there are no constraints.
+-->
+## Constraints
+
+- Existing specification creation requests that pass only a name must remain valid and must not require a config change.
+- Existing project config files without an identifier method field must remain valid.
+- Identifier values must not be able to create files outside the specification directory.
+- Generated and externally supplied prefixes must produce valid specification filenames on supported filesystems.
+
+
+<!--
+  ACCEPTANCE CRITERIA
+  The specific, binary conditions that define "done".
+  Format: bold title on the checkbox line, verifiable detail indented below.
+  Each criterion must be:
+    - Independently verifiable (pass/fail, not subjective)
+    - Traceable back to a requirement above
+    - Testable by someone who didn't write the code
+-->
+## Acceptance Criteria
+
+- [ ] **Default timestamp prefix is used**
+      When a user creates a specification with name `billing-export` and no identifier method or identifier value is configured or passed, the created specification filename starts with a sortable timestamp prefix followed by `billing-export`.
+- [ ] **Timestamp prefixes sort chronologically**
+      When two specifications are created at different times with the default method, sorting their filenames alphabetically orders them from older to newer.
+- [ ] **Counter prefix can be selected**
+      When a user selects the counter method and creates a specification named `billing-export`, the created specification filename starts with the next available counter prefix followed by `billing-export`.
+- [ ] **Counter prefixes increment**
+      When two specifications are created with the counter method in the same project, the second filename uses the next stored counter value after the first.
+- [ ] **Passed identifier is normalized as the prefix**
+      When a user creates a specification named `billing-export` and passes identifier `EXT-123`, the created specification filename starts with `ext-123` followed by `billing-export`.
+- [ ] **Passed identifier works with any configured generated method**
+      When the project is configured for timestamp or counter generation and a user passes identifier `EXT-123`, the created filename uses `ext-123` rather than a generated timestamp or counter.
+- [ ] **Special characters are normalized**
+      When a user creates a specification with identifier `Team.Alpha@Roadmap`, the created filename starts with `team-alpha-roadmap` followed by the requested name.
+- [ ] **Whitespace is not silently trimmed**
+      When a user passes a spec name or identifier with leading or trailing whitespace, creation fails with a clear error and no specification file is created.
+- [ ] **Configured method becomes the default**
+      When a project config sets the identifier method to counter and the user creates a specification without passing an identifier value, the created filename uses a counter prefix.
+- [ ] **External method requires an identifier**
+      When a project config selects the externally supplied identifier method and a user creates a specification without passing an identifier value, creation fails with a clear error and no specification file is created.
+- [ ] **External method succeeds with an identifier**
+      When a project config selects the externally supplied identifier method and a user creates a specification with identifier `EXT-123`, creation succeeds and the created filename starts with `ext-123` followed by the requested name.
+- [ ] **Timestamp collisions advance by seconds**
+      When the timestamp method would create a filename that already exists for the requested name, creation uses the next available second-level timestamp prefix instead of overwriting the existing file.
+
+
+<!--
+  TECHNICAL APPROACH
+  High-level technical direction to guide the planning agent. Include:
+    - Key architectural decisions already made
+    - Preferred patterns or technologies if known
+    - Integration points with existing systems
+    - Known risks or areas of uncertainty
+  Leave blank if you want the planner to propose the approach.
+-->
+## Technical Approach
+
+- Implement identifier generation inside the `spektacular spec new` path so installed skills and command wrappers inherit the behavior automatically.
+- Extend spec creation input to accept an optional `id` value. When present, normalize and validate it for filename safety, then use it as the prefix regardless of configured generation method.
+- Add input normalization for spec names and identifiers. Normalization lowercases accepted input and replaces special separators such as `.`, `@`, and internal whitespace with `-`; leading or trailing whitespace must fail rather than being trimmed.
+- Add optional config fields for the spec identifier method and current counter value. Supported methods should be `timestamp`, `counter`, and an externally supplied identifier mode. If the method field is omitted, use `timestamp`.
+- Treat the externally supplied identifier mode as a contract that creation requests must provide `id`; generated modes may still accept `id` as an override.
+- Prefer a timestamp format that sorts lexicographically in creation order, such as `YYYYMMDDHHMMSS`, similar to database migration filenames. If the computed timestamp target already exists, increment the timestamp by one second until an unused target is found.
+- For counter mode, persist the current counter value in project config and increment it for each counter-created spec. Use a stable, zero-padded numeric prefix so alphabetical order matches numeric order.
+- Keep the human-readable requested name as the suffix after the generated or supplied prefix.
+- Update command schemas, config loading/defaults, init output, and tests so the new inputs and config field are visible to agents and external callers.
+
+
+<!--
+  SUCCESS METRICS
+  How you will know the feature is working well after delivery. Be specific:
+    - Quantitative: "p99 latency < 200ms", "error rate < 0.1%"
+    - Behavioural: "users complete the flow without support intervention"
+  Leave blank if not applicable.
+-->
+## Success Metrics
+
+- New specifications created without custom settings are alphabetically sortable by creation time.
+- Projects can switch between timestamp and counter prefixes through configuration without changing installed agent skills.
+- External systems can create specifications whose filenames carry the normalized external identifier, with creation failing clearly when external-id mode is configured but no identifier is supplied.
+
+<!--
+  NON-GOALS
+  Explicitly state what this spec does NOT cover. This is as important as
+  the requirements — it prevents scope creep and sets clear expectations.
+  Examples:
+    - "Mobile support is out of scope (tracked in #456)"
+    - "Internationalisation will be addressed in a follow-up spec"
+  Leave blank if there are no explicit exclusions to call out.
+-->
+## Non-Goals
+
+- Renaming or migrating existing specification files is out of scope.
+- Building a direct integration with any specific external system is out of scope.
+- Changing the contents or step order of the specification authoring workflow is out of scope.
+- Applying the same identifier method to plans or implementation artifacts is out of scope unless a later spec requests it.

--- a/.spektacular/state.json
+++ b/.spektacular/state.json
@@ -12,9 +12,9 @@
     "update_repo_changelog",
     "finished"
   ],
-  "created_at": "2026-05-08T21:10:12.019613Z",
-  "updated_at": "2026-05-09T13:29:06.06168Z",
+  "created_at": "2026-05-09T17:32:55.684958Z",
+  "updated_at": "2026-05-10T16:16:22.701914Z",
   "data": {
-    "name": "spec-id-prefix-method"
+    "name": "20260509154708-notion-artifact-sync"
   }
 }

--- a/.spektacular/state.json
+++ b/.spektacular/state.json
@@ -1,11 +1,20 @@
 {
-  "current_step": "overview",
+  "current_step": "finished",
   "completed_steps": [
-    "new"
+    "new",
+    "read_plan",
+    "analyze",
+    "implement",
+    "test",
+    "verify",
+    "update_plan",
+    "update_changelog",
+    "update_repo_changelog",
+    "finished"
   ],
-  "created_at": "2026-04-19T17:02:31.870898072Z",
-  "updated_at": "2026-04-19T17:02:31.871201179Z",
+  "created_at": "2026-05-08T21:10:12.019613Z",
+  "updated_at": "2026-05-09T13:29:06.06168Z",
   "data": {
-    "name": "testing"
+    "name": "spec-id-prefix-method"
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## spec-id-prefix-method
+
+Spec creation now uses CLI-owned identifier prefixes. By default, `spec new` creates timestamp-prefixed spec names, accepts an optional `id` for external systems, and can be configured with `spec.id_method: timestamp`, `counter`, or `external`. Callers should use the returned `spec_name` and `spec_path` because requested names and ids are normalized before workflow state and files are created.
+
 ## 19_codex_integration
 
 Spektacular now ships first-class support for OpenAI Codex alongside Claude Code and Bob. `spektacular init codex` installs the three workflow entry points — spec, plan, and implement — as native SKILL.md files, so Codex users can invoke `$spek-new`, `$spek-plan`, and `$spek-implement` out of the box. As part of this release the workflow entry points become the canonical artefact type across every supported agent: slash commands for Claude and Bob are now thin wrappers that simply invoke the matching skill, and workflow instructions live in one place rather than being copied per-agent. Existing Claude and Bob users should re-run `spektacular init <agent>` once to pick up the new layout.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 20260509154708-notion-artifact-sync
+
+Spektacular can now be configured to keep specs and plans in linked Notion databases while agents work through an ignored local cache. The new Notion setup, doctor, cache, pull, push, commit, and merge commands give agents a structured MCP workflow for validating databases, using external Notion IDs, syncing changed artifacts, and surfacing conflicts before overwriting another user's work. Local filesystem projects remain the default and continue to use the existing specs and plans layout.
+
 ## spec-id-prefix-method
 
 Spec creation now uses CLI-owned identifier prefixes. By default, `spec new` creates timestamp-prefixed spec names, accepts an optional `id` for external systems, and can be configured with `spec.id_method: timestamp`, `counter`, or `external`. Callers should use the returned `spec_name` and `spec_path` because requested names and ids are normalized before workflow state and files are created.

--- a/README.md
+++ b/README.md
@@ -57,20 +57,28 @@ Or download a pre-built binary from the [releases page](https://github.com/nicho
 ### Usage
 
 ```bash
-# 1. Initialize a new project
-spektacular init
+# 1. Initialize a new project for your agent
+spektacular init claude
 
-# 2. Create a spec from template
-spektacular new auth-feature --title "User Authentication"
+# 2. Create a spec from the workflow
+spektacular spec new --data '{"name":"auth-feature"}'
 
-# 3. Edit the spec to add your requirements
-$EDITOR .spektacular/specs/auth-feature.md
+# 3. Edit the spec_path returned by the command to add your requirements
+$EDITOR .spektacular/specs/<returned-spec-name>.md
 
-# 4. Generate an implementation plan
-spektacular plan .spektacular/specs/auth-feature.md
+# 4. Generate an implementation plan using the returned spec_name
+spektacular plan new --data '{"name":"<returned-spec-name>"}'
 ```
 
-The plan command opens the TUI, runs the planning agent, and writes output to `.spektacular/plans/auth-feature/`.
+Spec names are normalized and prefixed by the CLI. Use the returned `spec_name` and `spec_path` for follow-up workflows instead of assuming the requested `name` is the final filename.
+
+External systems can pass their own identifier as the prefix:
+
+```bash
+spektacular spec new --data '{"name":"billing-export","id":"EXT-123"}'
+```
+
+Passing `id` is accepted for timestamp and counter projects and is required when `spec.id_method` is `external`.
 
 ## Spec Format
 
@@ -105,15 +113,15 @@ Login flow completes in under 3 seconds.
 Social login with Apple or Microsoft.
 ```
 
-Create a new spec with `spektacular new <name>` to get this template.
+Create a new spec with `spektacular spec new --data '{"name":"auth-feature"}'` to get this template.
 
 ## Project Structure
 
-Running `spektacular init` creates:
+Running `spektacular init <agent>` creates:
 
 ```
 .spektacular/
-├── config.yaml              # Model routing, complexity thresholds
+├── config.yaml              # CLI command, agent, debug, and spec ID settings
 ├── specs/                   # Your specification files
 ├── plans/                   # Generated plans (plan.md, research.md, context.md)
 └── knowledge/               # Project knowledge base
@@ -127,22 +135,25 @@ The knowledge directory feeds context to the planning agent. Adding architecture
 
 ## Configuration
 
-`.spektacular/config.yaml` controls model selection and complexity thresholds:
+`.spektacular/config.yaml` controls the installed agent command and spec identifier behavior:
 
 ```yaml
-models:
-  default: anthropic/claude-3-5-sonnet-20241022
-  tiers:
-    simple: anthropic/claude-3-5-haiku-20241022    # score 0.0–0.3
-    medium: anthropic/claude-3-5-sonnet-20241022   # score 0.3–0.6
-    complex: anthropic/claude-3-opus-20240229      # score 0.6+
-
-complexity:
-  thresholds:
-    simple: 0.3
-    medium: 0.6
-    complex: 0.8
+command: spektacular
+agent: claude
+debug:
+  enabled: false
+spec:
+  id_method: timestamp
+  counter: 0
 ```
+
+`spec.id_method` controls the prefix used for new spec filenames:
+
+- `timestamp` (default): creates names like `20260509010203-billing-export`; collisions bump by one second until unused.
+- `counter`: creates names like `000001-billing-export` and persists the latest value in `spec.counter`.
+- `external`: requires an `id` in `spec new --data`; useful when another system owns the identifier.
+
+Names and ids are normalized to lowercase, with accepted separators such as `.`, `@`, `-`, and internal whitespace converted to hyphens. Leading or trailing whitespace, path separators, and control characters are rejected.
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Running `spektacular init <agent>` creates:
 ├── config.yaml              # CLI command, agent, debug, and spec ID settings
 ├── specs/                   # Your specification files
 ├── plans/                   # Generated plans (plan.md, research.md, context.md)
+├── cache/notion/            # Ignored Notion-backed working cache, when enabled
 └── knowledge/               # Project knowledge base
     ├── conventions.md       # Code style and standards
     ├── architecture/        # System design docs
@@ -145,6 +146,12 @@ debug:
 spec:
   id_method: timestamp
   counter: 0
+artifacts:
+  backend: local
+  cache_dir: cache/notion
+  notion:
+    spec_id_property: "Spec ID"
+    plan_id_property: "Plan ID"
 ```
 
 `spec.id_method` controls the prefix used for new spec filenames:
@@ -154,6 +161,47 @@ spec:
 - `external`: requires an `id` in `spec new --data`; useful when another system owns the identifier.
 
 Names and ids are normalized to lowercase, with accepted separators such as `.`, `@`, `-`, and internal whitespace converted to hyphens. Leading or trailing whitespace, path separators, and control characters are rejected.
+
+`artifacts.backend` controls where specs and plans live:
+
+- `local` (default): uses `.spektacular/specs` and `.spektacular/plans`.
+- `notion`: uses linked Notion data sources and an ignored local cache under `.spektacular/cache/notion`.
+
+Notion mode requires `spec.id_method: external`. The external ID comes from the Notion `Spec ID` auto-increment property. Plans use a required `Plan ID` auto-increment property.
+
+### Notion mode
+
+The binary does not call Notion directly. Agents use Notion MCP to fetch, create, and update pages, then pass normalized snapshots or remote metadata to Spektacular.
+
+To create new Notion databases, ask the CLI for MCP instructions:
+
+```bash
+spektacular notion init --data '{"base_page_url":"https://www.notion.so/..."}'
+```
+
+To link existing databases, fetch both data sources with Notion MCP and pass the snapshots:
+
+```bash
+spektacular notion link --data '{"specs":{...},"plans":{...}}'
+```
+
+`notion link` validates the same schema rules as `notion doctor`. If fixable or blocking issues exist, it reports them and does not write config. Use doctor to inspect and prepare repairs:
+
+```bash
+spektacular notion doctor --data '{"specs":{...},"plans":{...}}'
+spektacular notion doctor --apply --approve-additive --data '{"specs":{...},"plans":{...}}'
+```
+
+Doctor repairs are safe additive schema changes only, and require explicit approval. Apply the returned `notion_update_data_source` instructions through Notion MCP, fetch fresh snapshots, then run `notion link` again.
+
+Agents keep a local working cache in `.spektacular/cache/notion`. Use `notion cache pull` after MCP fetches, `notion cache prepare-push` before MCP updates, `notion cache commit-push` after a successful MCP update, and `notion cache resolve-merge` when a remote page changed since the local baseline.
+
+```bash
+spektacular notion cache pull --data '{"kind":"spec","name":"<spec_name>","content":"<markdown>","remote":{"notion_url":"<page_url>","page_id":"<page_id>","data_source_url":"<collection_url>","external_id":"<spec_id>","remote_version":"<last_edited_time>"}}'
+spektacular notion cache prepare-push --data '{"kind":"spec","name":"<spec_name>","remote_version":"<latest_last_edited_time>","remote_content":"<latest_markdown>"}'
+```
+
+If `prepare-push` returns `merge_required`, present the returned baseline, local, and remote content to the user or agent. Do not overwrite Notion until `resolve-merge` records resolved content and a retry returns `ready`.
 
 ## Roadmap
 
@@ -229,6 +277,11 @@ tests/harbor/jobs/<timestamp>/
 | Task | Description |
 |---|---|
 | `tests/harbor/spec-workflow` | Full spec creation workflow through all 10 steps |
+
+Local unit and command tests cover both artifact backends:
+
+- Local workflow compatibility remains covered by the existing spec, plan, implement, and Harbor workflow tests.
+- Notion mode coverage includes config validation, schema link/doctor reports, cache pull/push/merge contracts, conflict output, and Notion-backed workflow startup/cache behavior.
 
 ## Building from Source
 

--- a/cmd/implement.go
+++ b/cmd/implement.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"regexp"
 
+	"github.com/jumppad-labs/spektacular/internal/artifact"
+	"github.com/jumppad-labs/spektacular/internal/config"
 	"github.com/jumppad-labs/spektacular/internal/output"
 	"github.com/jumppad-labs/spektacular/internal/steps/implement"
 	"github.com/jumppad-labs/spektacular/internal/store"
@@ -111,7 +113,15 @@ func runImplementNew(cmd *cobra.Command, _ []string) error {
 
 	// Precondition: the plan file must exist before an implement workflow
 	// can run against it. The workflow operates on an already-approved plan.
-	planPath := filepath.Join(dataDir, implement.PlanFilePath(input.Name))
+	planRelPath := implement.PlanFilePath(input.Name)
+	if cfg.Artifacts.Backend == config.ArtifactBackendNotion {
+		resolvedPath, err := artifact.Path(cfg, artifact.KindPlan, input.Name)
+		if err != nil {
+			return err
+		}
+		planRelPath = resolvedPath
+	}
+	planPath := filepath.Join(dataDir, planRelPath)
 	if _, statErr := os.Stat(planPath); statErr != nil {
 		return fmt.Errorf("plan file not found at %s — run 'plan new' first or check the name", planPath)
 	}
@@ -123,7 +133,7 @@ func runImplementNew(cmd *cobra.Command, _ []string) error {
 		_ = os.Remove(statePath)
 	}
 
-	wfCfg := workflow.Config{Command: cfg.Command, DryRun: dryRun}
+	wfCfg := workflow.Config{Command: cfg.Command, DryRun: dryRun, Project: cfg}
 	steps := implement.Steps()
 	out := output.New(cmd.OutOrStdout(), globalFields)
 	wf := workflow.New(steps, statePath, wfCfg, store.NewFileStore(dataDir), out)
@@ -178,7 +188,7 @@ func runImplementGoto(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	wfCfg := workflow.Config{Command: cfg.Command, DryRun: dryRun}
+	wfCfg := workflow.Config{Command: cfg.Command, DryRun: dryRun, Project: cfg}
 	steps := implement.Steps()
 	out := output.New(cmd.OutOrStdout(), globalFields)
 	wf := workflow.New(steps, stateFilePath(dataDir), wfCfg, store.NewFileStore(dataDir), out)

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -123,6 +123,7 @@ func TestInit_Codex(t *testing.T) {
 		require.NoError(t, err, "expected skill file %s to exist", skillPath)
 		require.Contains(t, string(data), expected)
 		require.NotContains(t, string(data), "{{command}}")
+		require.Contains(t, string(data), "notion status")
 	}
 
 	// Codex has no per-repo slash-command mechanism — no command wrappers or

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/jumppad-labs/spektacular/internal/agent"
+	"github.com/jumppad-labs/spektacular/internal/config"
 	"github.com/stretchr/testify/require"
 )
 
@@ -159,6 +160,12 @@ func TestInit_CustomCommand(t *testing.T) {
 	// Re-init — should use the custom command when rendering templates.
 	rootCmd.SetArgs([]string{"init", "claude"})
 	require.NoError(t, rootCmd.Execute())
+
+	cfg, err := config.FromYAMLFile(configPath)
+	require.NoError(t, err)
+	require.Equal(t, "go run .", cfg.Command)
+	require.Equal(t, "timestamp", cfg.Spec.IDMethod)
+	require.Equal(t, 0, cfg.Spec.Counter)
 
 	skillPath := filepath.Join(dir, ".claude", "skills", "spek-new", "SKILL.md")
 	skillData, err := os.ReadFile(skillPath)

--- a/cmd/notion.go
+++ b/cmd/notion.go
@@ -1,0 +1,444 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/jumppad-labs/spektacular/internal/config"
+	"github.com/jumppad-labs/spektacular/internal/notion/schema"
+	"github.com/jumppad-labs/spektacular/internal/notion/setup"
+	"github.com/jumppad-labs/spektacular/internal/output"
+	"github.com/jumppad-labs/spektacular/internal/project"
+	"github.com/spf13/cobra"
+)
+
+var notionCmd = &cobra.Command{
+	Use:   "notion",
+	Short: "Validate and link Notion artifact databases",
+}
+
+var notionInitCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Print Notion MCP instructions for creating Spektacular databases",
+	RunE:  runNotionInit,
+}
+
+var notionLinkCmd = &cobra.Command{
+	Use:   "link",
+	Short: "Validate and link existing Notion artifact databases",
+	RunE:  runNotionLink,
+}
+
+var notionDoctorCmd = &cobra.Command{
+	Use:   "doctor",
+	Short: "Validate linked Notion databases and prepare safe repairs",
+	RunE:  runNotionDoctor,
+}
+
+var notionStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show Notion artifact backend status",
+	RunE:  runNotionStatus,
+}
+
+type notionInput struct {
+	BasePageURL     string          `json:"base_page_url"`
+	CacheDir        string          `json:"cache_dir"`
+	SpecsDataSource string          `json:"specs_data_source"`
+	PlansDataSource string          `json:"plans_data_source"`
+	SpecIDProperty  string          `json:"spec_id_property"`
+	PlanIDProperty  string          `json:"plan_id_property"`
+	Specs           json.RawMessage `json:"specs"`
+	Plans           json.RawMessage `json:"plans"`
+	Apply           bool            `json:"apply"`
+	ApprovedFixIDs  []string        `json:"approved_fix_ids"`
+}
+
+type notionResult struct {
+	Status           string              `json:"status"`
+	Configured       bool                `json:"configured,omitempty"`
+	Backend          string              `json:"backend,omitempty"`
+	CacheDir         string              `json:"cache_dir,omitempty"`
+	BasePageURL      string              `json:"base_page_url,omitempty"`
+	SpecsDataSource  string              `json:"specs_data_source,omitempty"`
+	PlansDataSource  string              `json:"plans_data_source,omitempty"`
+	SpecIDProperty   string              `json:"spec_id_property,omitempty"`
+	PlanIDProperty   string              `json:"plan_id_property,omitempty"`
+	Report           schema.Report       `json:"report,omitempty"`
+	Instructions     []setup.Instruction `json:"instructions,omitempty"`
+	ApprovalRequired bool                `json:"approval_required,omitempty"`
+	AppliedRepairs   []schema.Repair     `json:"applied_repairs,omitempty"`
+	UpdatedSpecs     *schema.DataSource  `json:"updated_specs,omitempty"`
+	UpdatedPlans     *schema.DataSource  `json:"updated_plans,omitempty"`
+	ReportAfter      *schema.Report      `json:"report_after,omitempty"`
+	Next             string              `json:"next,omitempty"`
+}
+
+func runNotionInit(cmd *cobra.Command, _ []string) error {
+	if schemaFlag, _ := cmd.Flags().GetBool("schema"); schemaFlag {
+		return writeNotionSchema(cmd, false)
+	}
+
+	input, err := readNotionInput(cmd)
+	if err != nil {
+		return err
+	}
+	res := notionResult{
+		Status:       "instructions",
+		BasePageURL:  input.BasePageURL,
+		Instructions: setup.CreateDatabaseInstructions(input.BasePageURL),
+		Next:         "Use Notion MCP to create/fetch the databases, then run `spektacular notion link` with the fetched snapshots.",
+	}
+	return output.Write(cmd.OutOrStdout(), res, globalFields)
+}
+
+func runNotionLink(cmd *cobra.Command, _ []string) error {
+	if schemaFlag, _ := cmd.Flags().GetBool("schema"); schemaFlag {
+		return writeNotionSchema(cmd, true)
+	}
+
+	input, specs, plans, opts, err := readNotionValidationInput(cmd)
+	if err != nil {
+		return err
+	}
+	report := schema.ValidatePair(specs, plans, opts)
+	if !report.Valid {
+		res := notionResult{
+			Status:          "needs_doctor",
+			Configured:      false,
+			BasePageURL:     input.BasePageURL,
+			SpecsDataSource: opts.SpecsDataSource,
+			PlansDataSource: opts.PlansDataSource,
+			SpecIDProperty:  opts.SpecIDProperty,
+			PlanIDProperty:  opts.PlanIDProperty,
+			Report:          report,
+			Instructions:    setup.RepairInstructions(report.Repairs),
+			Next:            "Run `spektacular notion doctor` and apply approved safe repairs before linking.",
+		}
+		if len(report.BlockingIssues) > 0 {
+			res.Status = "blocking_issues"
+			res.Next = "Resolve blocking Notion schema issues, then run `spektacular notion link` again."
+		}
+		return output.Write(cmd.OutOrStdout(), res, globalFields)
+	}
+
+	cfg, err := notionConfigFromInput(input, opts)
+	if err != nil {
+		return err
+	}
+	if err := ensureNotionProject(cfg); err != nil {
+		return err
+	}
+	cfgPath, err := configFilePath()
+	if err != nil {
+		return err
+	}
+	if err := cfg.ToYAMLFile(cfgPath); err != nil {
+		return fmt.Errorf("writing config: %w", err)
+	}
+
+	res := notionResult{
+		Status:          "linked",
+		Configured:      true,
+		Backend:         cfg.Artifacts.Backend,
+		CacheDir:        cfg.Artifacts.CacheDir,
+		BasePageURL:     cfg.Artifacts.Notion.BasePageURL,
+		SpecsDataSource: cfg.Artifacts.Notion.SpecsDataSource,
+		PlansDataSource: cfg.Artifacts.Notion.PlansDataSource,
+		SpecIDProperty:  cfg.Artifacts.Notion.SpecIDProperty,
+		PlanIDProperty:  cfg.Artifacts.Notion.PlanIDProperty,
+		Report:          report,
+		Next:            "Pull or create Notion-backed artifacts before starting workflow work.",
+	}
+	return output.Write(cmd.OutOrStdout(), res, globalFields)
+}
+
+func runNotionDoctor(cmd *cobra.Command, _ []string) error {
+	if schemaFlag, _ := cmd.Flags().GetBool("schema"); schemaFlag {
+		return writeNotionSchema(cmd, true)
+	}
+
+	input, specs, plans, opts, err := readNotionValidationInput(cmd)
+	if err != nil {
+		return err
+	}
+	applyFlag, _ := cmd.Flags().GetBool("apply")
+	approveAll, _ := cmd.Flags().GetBool("approve-additive")
+	approvedFlag, _ := cmd.Flags().GetString("approve")
+	input.Apply = input.Apply || applyFlag
+	input.ApprovedFixIDs = append(input.ApprovedFixIDs, splitCSV(approvedFlag)...)
+
+	report := schema.ValidatePair(specs, plans, opts)
+	res := notionResult{
+		Status:          "checked",
+		BasePageURL:     input.BasePageURL,
+		SpecsDataSource: opts.SpecsDataSource,
+		PlansDataSource: opts.PlansDataSource,
+		SpecIDProperty:  opts.SpecIDProperty,
+		PlanIDProperty:  opts.PlanIDProperty,
+		Report:          report,
+		Instructions:    setup.RepairInstructions(report.Repairs),
+	}
+	if report.Valid {
+		res.Status = "valid"
+		return output.Write(cmd.OutOrStdout(), res, globalFields)
+	}
+	if !input.Apply {
+		res.Next = "Review fixable repairs, resolve blocking issues, then rerun with --apply and explicit approval."
+		return output.Write(cmd.OutOrStdout(), res, globalFields)
+	}
+	if len(report.BlockingIssues) > 0 {
+		res.Status = "blocking_issues"
+		res.Next = "Resolve blocking Notion schema issues before applying safe additive repairs."
+		return output.Write(cmd.OutOrStdout(), res, globalFields)
+	}
+
+	approvedIDs := input.ApprovedFixIDs
+	if approveAll {
+		approvedIDs = make([]string, 0, len(report.Repairs))
+		for _, repair := range report.Repairs {
+			approvedIDs = append(approvedIDs, repair.ID)
+		}
+	}
+	if len(approvedIDs) == 0 {
+		res.Status = "approval_required"
+		res.ApprovalRequired = true
+		res.Next = "Rerun with --approve-additive or --approve <repair-id> after user/agent approval."
+		return output.Write(cmd.OutOrStdout(), res, globalFields)
+	}
+
+	updatedSpecs, updatedPlans, applied := schema.ApplyApprovedRepairs(specs, plans, report.Repairs, approvedIDs)
+	after := schema.ValidatePair(updatedSpecs, updatedPlans, opts)
+	instructions := setup.RepairInstructions(applied)
+	res.Status = "repairs_prepared"
+	res.Instructions = instructions
+	res.AppliedRepairs = applied
+	res.UpdatedSpecs = &updatedSpecs
+	res.UpdatedPlans = &updatedPlans
+	res.ReportAfter = &after
+	res.Next = "Apply the prepared instructions through Notion MCP, fetch fresh snapshots, then rerun `spektacular notion link`."
+	if after.Valid {
+		res.Next = "Apply the prepared instructions through Notion MCP, then rerun `spektacular notion link` with fresh snapshots."
+	}
+	return output.Write(cmd.OutOrStdout(), res, globalFields)
+}
+
+func runNotionStatus(cmd *cobra.Command, _ []string) error {
+	if schemaFlag, _ := cmd.Flags().GetBool("schema"); schemaFlag {
+		return output.Write(cmd.OutOrStdout(), commandSchema{
+			Input: nil,
+			Output: &schemaObj{Type: "object", Properties: map[string]*schemaProp{
+				"status":            {Type: "string"},
+				"configured":        {Type: "boolean"},
+				"backend":           {Type: "string"},
+				"cache_dir":         {Type: "string"},
+				"specs_data_source": {Type: "string"},
+				"plans_data_source": {Type: "string"},
+			}},
+		}, "")
+	}
+
+	cfg, err := loadConfig()
+	if err != nil {
+		return err
+	}
+	configured := cfg.Artifacts.Backend == config.ArtifactBackendNotion &&
+		cfg.Artifacts.Notion.SpecsDataSource != "" &&
+		cfg.Artifacts.Notion.PlansDataSource != ""
+	status := "local"
+	if cfg.Artifacts.Backend == config.ArtifactBackendNotion {
+		status = "configured"
+		if !configured {
+			status = "incomplete"
+		}
+	}
+	return output.Write(cmd.OutOrStdout(), notionResult{
+		Status:          status,
+		Configured:      configured,
+		Backend:         cfg.Artifacts.Backend,
+		CacheDir:        cfg.Artifacts.CacheDir,
+		BasePageURL:     cfg.Artifacts.Notion.BasePageURL,
+		SpecsDataSource: cfg.Artifacts.Notion.SpecsDataSource,
+		PlansDataSource: cfg.Artifacts.Notion.PlansDataSource,
+		SpecIDProperty:  cfg.Artifacts.Notion.SpecIDProperty,
+		PlanIDProperty:  cfg.Artifacts.Notion.PlanIDProperty,
+	}, globalFields)
+}
+
+func writeNotionSchema(cmd *cobra.Command, requiresSnapshots bool) error {
+	props := map[string]*schemaProp{
+		"base_page_url":     {Type: "string"},
+		"cache_dir":         {Type: "string"},
+		"specs_data_source": {Type: "string"},
+		"plans_data_source": {Type: "string"},
+		"spec_id_property":  {Type: "string"},
+		"plan_id_property":  {Type: "string"},
+		"specs":             {Type: "object"},
+		"plans":             {Type: "object"},
+	}
+	required := []string(nil)
+	if requiresSnapshots {
+		required = []string{"specs", "plans"}
+	}
+	return output.Write(cmd.OutOrStdout(), commandSchema{
+		Input: &schemaObj{Type: "object", Properties: props, Required: required},
+		Output: &schemaObj{Type: "object", Properties: map[string]*schemaProp{
+			"status":       {Type: "string"},
+			"configured":   {Type: "boolean"},
+			"report":       {Type: "object"},
+			"instructions": {Type: "array"},
+		}},
+	}, "")
+}
+
+func readNotionValidationInput(cmd *cobra.Command) (notionInput, schema.DataSource, schema.DataSource, schema.ValidationOptions, error) {
+	input, err := readNotionInput(cmd)
+	if err != nil {
+		return notionInput{}, schema.DataSource{}, schema.DataSource{}, schema.ValidationOptions{}, err
+	}
+
+	specsRaw, err := snapshotRaw(cmd, input.Specs, "specs-file")
+	if err != nil {
+		return notionInput{}, schema.DataSource{}, schema.DataSource{}, schema.ValidationOptions{}, err
+	}
+	plansRaw, err := snapshotRaw(cmd, input.Plans, "plans-file")
+	if err != nil {
+		return notionInput{}, schema.DataSource{}, schema.DataSource{}, schema.ValidationOptions{}, err
+	}
+
+	specs, err := schema.ParseDataSource(specsRaw)
+	if err != nil {
+		return notionInput{}, schema.DataSource{}, schema.DataSource{}, schema.ValidationOptions{}, fmt.Errorf("parsing specs snapshot: %w", err)
+	}
+	plans, err := schema.ParseDataSource(plansRaw)
+	if err != nil {
+		return notionInput{}, schema.DataSource{}, schema.DataSource{}, schema.ValidationOptions{}, fmt.Errorf("parsing plans snapshot: %w", err)
+	}
+
+	opts := schema.ValidationOptions{
+		SpecsDataSource: input.SpecsDataSource,
+		PlansDataSource: input.PlansDataSource,
+		SpecIDProperty:  input.SpecIDProperty,
+		PlanIDProperty:  input.PlanIDProperty,
+	}
+	if opts.SpecsDataSource == "" {
+		opts.SpecsDataSource = specs.URL
+	}
+	if opts.PlansDataSource == "" {
+		opts.PlansDataSource = plans.URL
+	}
+	if opts.SpecIDProperty == "" {
+		opts.SpecIDProperty = config.DefaultSpecIDPropertyName
+	}
+	if opts.PlanIDProperty == "" {
+		opts.PlanIDProperty = config.DefaultPlanIDPropertyName
+	}
+	return input, specs, plans, opts, nil
+}
+
+func readNotionInput(cmd *cobra.Command) (notionInput, error) {
+	dataStr, _ := cmd.Flags().GetString("data")
+	if dataStr == "" {
+		return notionInput{}, nil
+	}
+	var input notionInput
+	if err := json.Unmarshal([]byte(dataStr), &input); err != nil {
+		return notionInput{}, fmt.Errorf("parsing --data: %w", err)
+	}
+	return input, nil
+}
+
+func snapshotRaw(cmd *cobra.Command, inline json.RawMessage, fileFlag string) ([]byte, error) {
+	filePath, _ := cmd.Flags().GetString(fileFlag)
+	if len(inline) > 0 && filePath != "" {
+		return nil, fmt.Errorf("%s and inline snapshot data are mutually exclusive", fileFlag)
+	}
+	if len(inline) > 0 {
+		return inline, nil
+	}
+	if filePath == "" {
+		return nil, fmt.Errorf("snapshot is required via --data or --%s", fileFlag)
+	}
+	raw, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", fileFlag, err)
+	}
+	return raw, nil
+}
+
+func notionConfigFromInput(input notionInput, opts schema.ValidationOptions) (config.Config, error) {
+	cfg, err := loadConfig()
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return config.Config{}, err
+		}
+		cfg = config.NewDefault()
+	}
+	if input.CacheDir == "" {
+		input.CacheDir = config.DefaultNotionCacheDir
+	}
+	cfg.Spec.IDMethod = config.SpecIDMethodExternal
+	cfg.Artifacts.Backend = config.ArtifactBackendNotion
+	cfg.Artifacts.CacheDir = input.CacheDir
+	cfg.Artifacts.Notion.BasePageURL = input.BasePageURL
+	cfg.Artifacts.Notion.SpecsDataSource = opts.SpecsDataSource
+	cfg.Artifacts.Notion.PlansDataSource = opts.PlansDataSource
+	cfg.Artifacts.Notion.SpecIDProperty = opts.SpecIDProperty
+	cfg.Artifacts.Notion.PlanIDProperty = opts.PlanIDProperty
+	if err := cfg.Validate(); err != nil {
+		return config.Config{}, err
+	}
+	return cfg, nil
+}
+
+func ensureNotionProject(cfg config.Config) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("getting working directory: %w", err)
+	}
+	if err := project.InitWithOptions(cwd, project.InitOptions{
+		Force:                   true,
+		Config:                  cfg,
+		CreateLocalArtifactDirs: false,
+		CreateNotionCacheDir:    true,
+	}); err != nil {
+		return fmt.Errorf("initialising Notion project cache: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Join(cwd, ".spektacular", cfg.Artifacts.CacheDir), 0o755); err != nil {
+		return fmt.Errorf("creating Notion cache: %w", err)
+	}
+	return nil
+}
+
+func splitCSV(value string) []string {
+	if value == "" {
+		return nil
+	}
+	parts := strings.Split(value, ",")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
+}
+
+func init() {
+	notionCmd.PersistentFlags().Bool("schema", false, "Print the input/output schema for this subcommand and exit")
+	notionCmd.PersistentFlags().StringP("data", "d", "", "JSON input")
+
+	notionLinkCmd.Flags().String("specs-file", "", "Read the Notion MCP Specs data source snapshot from a JSON file")
+	notionLinkCmd.Flags().String("plans-file", "", "Read the Notion MCP Plans data source snapshot from a JSON file")
+	notionDoctorCmd.Flags().String("specs-file", "", "Read the Notion MCP Specs data source snapshot from a JSON file")
+	notionDoctorCmd.Flags().String("plans-file", "", "Read the Notion MCP Plans data source snapshot from a JSON file")
+	notionDoctorCmd.Flags().Bool("apply", false, "Prepare approved safe additive repairs")
+	notionDoctorCmd.Flags().Bool("approve-additive", false, "Approve all safe additive repairs")
+	notionDoctorCmd.Flags().String("approve", "", "Comma-separated repair IDs to approve")
+
+	notionCmd.AddCommand(notionInitCmd, notionLinkCmd, notionDoctorCmd, notionStatusCmd)
+}

--- a/cmd/notion_cache.go
+++ b/cmd/notion_cache.go
@@ -1,0 +1,205 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	artifactsync "github.com/jumppad-labs/spektacular/internal/artifact/sync"
+	"github.com/jumppad-labs/spektacular/internal/config"
+	"github.com/jumppad-labs/spektacular/internal/output"
+	"github.com/jumppad-labs/spektacular/internal/store"
+	"github.com/spf13/cobra"
+)
+
+var notionCacheCmd = &cobra.Command{
+	Use:   "cache",
+	Short: "Manage Notion artifact cache sync contracts",
+}
+
+var notionCachePullCmd = &cobra.Command{
+	Use:   "pull",
+	Short: "Record Notion MCP content in the local artifact cache",
+	RunE:  runNotionCachePull,
+}
+
+var notionCacheStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show dirty/stale status for a cached Notion artifact",
+	RunE:  runNotionCacheStatus,
+}
+
+var notionCachePreparePushCmd = &cobra.Command{
+	Use:   "prepare-push",
+	Short: "Prepare a safe Notion MCP update or return a merge request",
+	RunE:  runNotionCachePreparePush,
+}
+
+var notionCacheCommitPushCmd = &cobra.Command{
+	Use:   "commit-push",
+	Short: "Record returned Notion MCP metadata after a successful update",
+	RunE:  runNotionCacheCommitPush,
+}
+
+var notionCacheResolveMergeCmd = &cobra.Command{
+	Use:   "resolve-merge",
+	Short: "Record resolved merge content before retrying a push",
+	RunE:  runNotionCacheResolveMerge,
+}
+
+func runNotionCachePull(cmd *cobra.Command, _ []string) error {
+	if schemaFlag, _ := cmd.Flags().GetBool("schema"); schemaFlag {
+		return writeCacheSchema(cmd)
+	}
+	var input artifactsync.PullRequest
+	if err := readCacheData(cmd, &input); err != nil {
+		return err
+	}
+	cfg, st, err := cacheConfigAndStore()
+	if err != nil {
+		return err
+	}
+	result, err := artifactsync.Pull(st, cfg, input)
+	if err != nil {
+		return err
+	}
+	return output.Write(cmd.OutOrStdout(), result, globalFields)
+}
+
+func runNotionCacheStatus(cmd *cobra.Command, _ []string) error {
+	if schemaFlag, _ := cmd.Flags().GetBool("schema"); schemaFlag {
+		return writeCacheSchema(cmd)
+	}
+	var input artifactsync.PushRequest
+	if err := readCacheData(cmd, &input); err != nil {
+		return err
+	}
+	cfg, st, err := cacheConfigAndStore()
+	if err != nil {
+		return err
+	}
+	result, err := artifactsync.Status(st, cfg, input)
+	if err != nil {
+		return err
+	}
+	return output.Write(cmd.OutOrStdout(), result, globalFields)
+}
+
+func runNotionCachePreparePush(cmd *cobra.Command, _ []string) error {
+	if schemaFlag, _ := cmd.Flags().GetBool("schema"); schemaFlag {
+		return writeCacheSchema(cmd)
+	}
+	var input artifactsync.PushRequest
+	if err := readCacheData(cmd, &input); err != nil {
+		return err
+	}
+	cfg, st, err := cacheConfigAndStore()
+	if err != nil {
+		return err
+	}
+	result, err := artifactsync.PreparePush(st, cfg, input)
+	if err != nil {
+		return err
+	}
+	return output.Write(cmd.OutOrStdout(), result, globalFields)
+}
+
+func runNotionCacheCommitPush(cmd *cobra.Command, _ []string) error {
+	if schemaFlag, _ := cmd.Flags().GetBool("schema"); schemaFlag {
+		return writeCacheSchema(cmd)
+	}
+	var input artifactsync.CommitRequest
+	if err := readCacheData(cmd, &input); err != nil {
+		return err
+	}
+	cfg, st, err := cacheConfigAndStore()
+	if err != nil {
+		return err
+	}
+	result, err := artifactsync.CommitPush(st, cfg, input)
+	if err != nil {
+		return err
+	}
+	return output.Write(cmd.OutOrStdout(), result, globalFields)
+}
+
+func runNotionCacheResolveMerge(cmd *cobra.Command, _ []string) error {
+	if schemaFlag, _ := cmd.Flags().GetBool("schema"); schemaFlag {
+		return writeCacheSchema(cmd)
+	}
+	var input artifactsync.MergeRequestInput
+	if err := readCacheData(cmd, &input); err != nil {
+		return err
+	}
+	cfg, st, err := cacheConfigAndStore()
+	if err != nil {
+		return err
+	}
+	result, err := artifactsync.ResolveMerge(st, cfg, input)
+	if err != nil {
+		return err
+	}
+	return output.Write(cmd.OutOrStdout(), result, globalFields)
+}
+
+func readCacheData(cmd *cobra.Command, target any) error {
+	dataStr, _ := cmd.Flags().GetString("data")
+	if dataStr == "" {
+		return fmt.Errorf("--data is required")
+	}
+	if err := json.Unmarshal([]byte(dataStr), target); err != nil {
+		return fmt.Errorf("parsing --data: %w", err)
+	}
+	return nil
+}
+
+func cacheConfigAndStore() (config.Config, store.Store, error) {
+	cfg, err := loadConfig()
+	if err != nil {
+		return config.Config{}, nil, err
+	}
+	dataDir, err := dataDir()
+	if err != nil {
+		return config.Config{}, nil, err
+	}
+	return cfg, store.NewFileStore(dataDir), nil
+}
+
+func writeCacheSchema(cmd *cobra.Command) error {
+	return output.Write(cmd.OutOrStdout(), commandSchema{
+		Input: &schemaObj{
+			Type: "object",
+			Properties: map[string]*schemaProp{
+				"kind":             {Type: "string"},
+				"name":             {Type: "string"},
+				"content":          {Type: "string"},
+				"remote":           {Type: "object"},
+				"remote_version":   {Type: "string"},
+				"remote_content":   {Type: "string"},
+				"resolved_content": {Type: "string"},
+				"notion_url":       {Type: "string"},
+				"page_id":          {Type: "string"},
+				"external_id":      {Type: "string"},
+			},
+		},
+		Output: &schemaObj{
+			Type: "object",
+			Properties: map[string]*schemaProp{
+				"status":        {Type: "string"},
+				"entry":         {Type: "object"},
+				"local_content": {Type: "string"},
+				"merge_request": {Type: "object"},
+			},
+		},
+	}, "")
+}
+
+func init() {
+	notionCacheCmd.AddCommand(
+		notionCachePullCmd,
+		notionCacheStatusCmd,
+		notionCachePreparePushCmd,
+		notionCacheCommitPushCmd,
+		notionCacheResolveMergeCmd,
+	)
+	notionCmd.AddCommand(notionCacheCmd)
+}

--- a/cmd/notion_cache_test.go
+++ b/cmd/notion_cache_test.go
@@ -1,0 +1,197 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jumppad-labs/spektacular/internal/artifact"
+	"github.com/jumppad-labs/spektacular/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+func writeNotionCacheConfig(t *testing.T, dir string) {
+	t.Helper()
+	cfg := config.NewDefault()
+	cfg.Spec.IDMethod = config.SpecIDMethodExternal
+	cfg.Artifacts.Backend = config.ArtifactBackendNotion
+	cfg.Artifacts.Notion.SpecsDataSource = "collection://specs"
+	cfg.Artifacts.Notion.PlansDataSource = "collection://plans"
+	dataDir := filepath.Join(dir, ".spektacular")
+	require.NoError(t, os.MkdirAll(dataDir, 0o755))
+	require.NoError(t, cfg.ToYAMLFile(filepath.Join(dataDir, "config.yaml")))
+}
+
+func cacheRemote(version string) artifact.RemoteMetadata {
+	return artifact.RemoteMetadata{
+		NotionURL:     "https://notion.so/spec",
+		PageID:        "page-123",
+		DataSourceURL: "collection://specs",
+		ExternalID:    "SPEC-1",
+		RemoteVersion: version,
+		Title:         "Spec 1",
+	}
+}
+
+func cacheData(t *testing.T, value any) string {
+	t.Helper()
+	raw, err := json.Marshal(value)
+	require.NoError(t, err)
+	return string(raw)
+}
+
+func runNotionCacheForTest(t *testing.T, args ...string) (map[string]any, error) {
+	t.Helper()
+	resetNotionCommandFlags(t)
+	stdout, _ := setupImplementCmd(t)
+	rootCmd.SetArgs(append([]string{"notion", "cache"}, args...))
+
+	err := rootCmd.Execute()
+	if err != nil {
+		return nil, err
+	}
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &result))
+	return result, nil
+}
+
+func TestNotionCachePullPrepareAndCommitPush(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeNotionCacheConfig(t, dir)
+
+	pull, err := runNotionCacheForTest(t, "pull", "--data", cacheData(t, map[string]any{
+		"kind":    "spec",
+		"name":    "spec-1",
+		"content": "baseline",
+		"remote":  cacheRemote("v1"),
+	}))
+	require.NoError(t, err)
+	require.Equal(t, "pulled", pull["status"])
+	require.FileExists(t, filepath.Join(dir, ".spektacular", "cache", "notion", "specs", "spec-1.md"))
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".spektacular", "cache", "notion", "specs", "spec-1.md"), []byte("local edit"), 0o644))
+	ready, err := runNotionCacheForTest(t, "prepare-push", "--data", cacheData(t, map[string]any{
+		"kind":           "spec",
+		"name":           "spec-1",
+		"remote_version": "v1",
+	}))
+	require.NoError(t, err)
+	require.Equal(t, "ready", ready["status"])
+	require.Equal(t, "local edit", ready["local_content"])
+
+	committed, err := runNotionCacheForTest(t, "commit-push", "--data", cacheData(t, map[string]any{
+		"kind":   "spec",
+		"name":   "spec-1",
+		"remote": cacheRemote("v2"),
+	}))
+	require.NoError(t, err)
+	require.Equal(t, "committed", committed["status"])
+	entry := committed["entry"].(map[string]any)
+	require.Equal(t, "v2", entry["remote_version"])
+}
+
+func TestNotionCachePreparePushReturnsMergeRequestByExternalID(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeNotionCacheConfig(t, dir)
+	_, err := runNotionCacheForTest(t, "pull", "--data", cacheData(t, map[string]any{
+		"kind":    "spec",
+		"name":    "spec-1",
+		"content": "baseline",
+		"remote":  cacheRemote("v1"),
+	}))
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".spektacular", "cache", "notion", "specs", "spec-1.md"), []byte("local edit"), 0o644))
+
+	result, err := runNotionCacheForTest(t, "prepare-push", "--data", cacheData(t, map[string]any{
+		"kind":           "spec",
+		"external_id":    "SPEC-1",
+		"remote_version": "v2",
+		"remote_content": "remote edit",
+	}))
+	require.NoError(t, err)
+	require.Equal(t, "merge_required", result["status"])
+	merge := result["merge_request"].(map[string]any)
+	require.Equal(t, "baseline", merge["baseline_content"])
+	require.Equal(t, "local edit", merge["local_content"])
+	require.Equal(t, "remote edit", merge["remote_content"])
+	require.Equal(t, "Merge baseline, local, and remote content; then run resolve-merge before retrying prepare-push.", merge["required_action"])
+}
+
+func TestNotionCacheStatusCanLocateByURLAndPageID(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeNotionCacheConfig(t, dir)
+	_, err := runNotionCacheForTest(t, "pull", "--data", cacheData(t, map[string]any{
+		"kind":    "spec",
+		"name":    "spec-1",
+		"content": "baseline",
+		"remote":  cacheRemote("v1"),
+	}))
+	require.NoError(t, err)
+
+	byURL, err := runNotionCacheForTest(t, "status", "--data", `{"notion_url":"https://notion.so/spec"}`)
+	require.NoError(t, err)
+	require.Equal(t, "status", byURL["status"])
+	entry := byURL["entry"].(map[string]any)
+	require.Equal(t, "spec-1", entry["name"])
+
+	byPageID, err := runNotionCacheForTest(t, "status", "--data", `{"page_id":"page-123"}`)
+	require.NoError(t, err)
+	require.Equal(t, "status", byPageID["status"])
+}
+
+func TestNotionCacheResolveMergeAllowsPrepareRetry(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeNotionCacheConfig(t, dir)
+	_, err := runNotionCacheForTest(t, "pull", "--data", cacheData(t, map[string]any{
+		"kind":    "spec",
+		"name":    "spec-1",
+		"content": "baseline",
+		"remote":  cacheRemote("v1"),
+	}))
+	require.NoError(t, err)
+
+	resolved, err := runNotionCacheForTest(t, "resolve-merge", "--data", cacheData(t, map[string]any{
+		"kind":             "spec",
+		"name":             "spec-1",
+		"remote":           cacheRemote("v2"),
+		"remote_content":   "remote edit",
+		"resolved_content": "merged content",
+	}))
+	require.NoError(t, err)
+	require.Equal(t, "resolved", resolved["status"])
+
+	ready, err := runNotionCacheForTest(t, "prepare-push", "--data", cacheData(t, map[string]any{
+		"kind":           "spec",
+		"name":           "spec-1",
+		"remote_version": "v2",
+	}))
+	require.NoError(t, err)
+	require.Equal(t, "ready", ready["status"])
+	require.Equal(t, "merged content", ready["local_content"])
+}
+
+func TestNotionCacheErrorsForMissingManifestAndMalformedRemote(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeNotionCacheConfig(t, dir)
+
+	_, err := runNotionCacheForTest(t, "prepare-push", "--data", `{"kind":"spec","name":"missing"}`)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not found")
+
+	_, err = runNotionCacheForTest(t, "pull", "--data", cacheData(t, map[string]any{
+		"kind":    "spec",
+		"name":    "spec-1",
+		"content": "baseline",
+		"remote": map[string]string{
+			"page_id": "page-123",
+		},
+	}))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "remote.notion_url")
+}

--- a/cmd/notion_test.go
+++ b/cmd/notion_test.go
@@ -1,0 +1,189 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jumppad-labs/spektacular/internal/config"
+	notionschema "github.com/jumppad-labs/spektacular/internal/notion/schema"
+	"github.com/stretchr/testify/require"
+)
+
+func resetNotionCommandFlags(t *testing.T) {
+	t.Helper()
+	reset := func() {
+		require.NoError(t, notionCmd.PersistentFlags().Set("schema", "false"))
+		require.NoError(t, notionCmd.PersistentFlags().Set("data", ""))
+		require.NoError(t, notionLinkCmd.Flags().Set("specs-file", ""))
+		require.NoError(t, notionLinkCmd.Flags().Set("plans-file", ""))
+		require.NoError(t, notionDoctorCmd.Flags().Set("specs-file", ""))
+		require.NoError(t, notionDoctorCmd.Flags().Set("plans-file", ""))
+		require.NoError(t, notionDoctorCmd.Flags().Set("apply", "false"))
+		require.NoError(t, notionDoctorCmd.Flags().Set("approve-additive", "false"))
+		require.NoError(t, notionDoctorCmd.Flags().Set("approve", ""))
+	}
+	reset()
+	t.Cleanup(reset)
+}
+
+func notionSpecsSnapshotForTest() notionschema.DataSource {
+	return notionschema.DataSource{
+		Name: "Specs",
+		URL:  "collection://specs",
+		Schema: map[string]notionschema.Property{
+			"Name":        {Name: "Name", Type: notionschema.TypeTitle},
+			"Spec ID":     {Name: "Spec ID", Type: notionschema.TypeAutoIncrementID},
+			"Created":     {Name: "Created", Type: notionschema.TypeCreatedTime},
+			"Last Edited": {Name: "Last Edited", Type: notionschema.TypeLastEditedTime},
+			"Status":      {Name: "Status", Type: notionschema.TypeSelect},
+			"Approval":    {Name: "Approval", Type: notionschema.TypeSelect},
+			"Tags":        {Name: "Tags", Type: notionschema.TypeMultiSelect},
+			"Author":      {Name: "Author", Type: notionschema.TypePerson},
+			"Reviewers":   {Name: "Reviewers", Type: notionschema.TypePerson},
+			"Plan":        {Name: "Plan", Type: notionschema.TypeRelation, DataSourceURL: "collection://plans"},
+		},
+	}
+}
+
+func notionPlansSnapshotForTest() notionschema.DataSource {
+	return notionschema.DataSource{
+		Name: "Plans",
+		URL:  "collection://plans",
+		Schema: map[string]notionschema.Property{
+			"Name":          {Name: "Name", Type: notionschema.TypeTitle},
+			"Plan ID":       {Name: "Plan ID", Type: notionschema.TypeAutoIncrementID},
+			"Created":       {Name: "Created", Type: notionschema.TypeCreatedTime},
+			"Last Edited":   {Name: "Last Edited", Type: notionschema.TypeLastEditedTime},
+			"Status":        {Name: "Status", Type: notionschema.TypeSelect},
+			"Approval":      {Name: "Approval", Type: notionschema.TypeSelect},
+			"Tags":          {Name: "Tags", Type: notionschema.TypeMultiSelect},
+			"Author":        {Name: "Author", Type: notionschema.TypePerson},
+			"Reviewers":     {Name: "Reviewers", Type: notionschema.TypePerson},
+			"Spec":          {Name: "Spec", Type: notionschema.TypeRelation, DataSourceURL: "collection://specs"},
+			"Linear Issues": {Name: "Linear Issues", Type: notionschema.TypeURL},
+		},
+	}
+}
+
+func notionDataForTest(t *testing.T, specs, plans notionschema.DataSource) string {
+	t.Helper()
+	data, err := json.Marshal(map[string]any{
+		"base_page_url":     "https://notion.example/base",
+		"specs_data_source": "collection://specs",
+		"plans_data_source": "collection://plans",
+		"spec_id_property":  "Spec ID",
+		"plan_id_property":  "Plan ID",
+		"specs":             specs,
+		"plans":             plans,
+	})
+	require.NoError(t, err)
+	return string(data)
+}
+
+func runNotionForTest(t *testing.T, args ...string) (map[string]any, error) {
+	t.Helper()
+	resetNotionCommandFlags(t)
+	stdout, _ := setupImplementCmd(t)
+	rootCmd.SetArgs(append([]string{"notion"}, args...))
+
+	err := rootCmd.Execute()
+	if err != nil {
+		return nil, err
+	}
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &result))
+	return result, nil
+}
+
+func TestNotionLink_CompatibleSnapshotsWriteConfig(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	result, err := runNotionForTest(t, "link", "--data", notionDataForTest(t, notionSpecsSnapshotForTest(), notionPlansSnapshotForTest()))
+	require.NoError(t, err)
+
+	require.Equal(t, "linked", result["status"])
+	require.Equal(t, true, result["configured"])
+	require.DirExists(t, filepath.Join(dir, ".spektacular", "cache", "notion"))
+	require.NoDirExists(t, filepath.Join(dir, ".spektacular", "specs"))
+	require.NoDirExists(t, filepath.Join(dir, ".spektacular", "plans"))
+
+	cfg, err := config.FromYAMLFile(filepath.Join(dir, ".spektacular", "config.yaml"))
+	require.NoError(t, err)
+	require.Equal(t, config.ArtifactBackendNotion, cfg.Artifacts.Backend)
+	require.Equal(t, config.SpecIDMethodExternal, cfg.Spec.IDMethod)
+	require.Equal(t, "collection://specs", cfg.Artifacts.Notion.SpecsDataSource)
+	require.Equal(t, "collection://plans", cfg.Artifacts.Notion.PlansDataSource)
+}
+
+func TestNotionLink_BlockingIssuesLeaveProjectUnconfigured(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	specs := notionSpecsSnapshotForTest()
+	delete(specs.Schema, "Spec ID")
+
+	result, err := runNotionForTest(t, "link", "--data", notionDataForTest(t, specs, notionPlansSnapshotForTest()))
+	require.NoError(t, err)
+
+	require.Equal(t, "blocking_issues", result["status"])
+	report := result["report"].(map[string]any)
+	require.Len(t, report["blocking_issues"], 1)
+	require.NoFileExists(t, filepath.Join(dir, ".spektacular", "config.yaml"))
+}
+
+func TestNotionDoctor_ReportsFixableAndBlockingIssues(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	specs := notionSpecsSnapshotForTest()
+	plans := notionPlansSnapshotForTest()
+	delete(specs.Schema, "Tags")
+	plans.Schema["Status"] = notionschema.Property{Name: "Status", Type: notionschema.TypeURL}
+
+	result, err := runNotionForTest(t, "doctor", "--data", notionDataForTest(t, specs, plans))
+	require.NoError(t, err)
+
+	require.Equal(t, "checked", result["status"])
+	report := result["report"].(map[string]any)
+	require.Len(t, report["fixable_issues"], 1)
+	require.Len(t, report["blocking_issues"], 1)
+	require.Len(t, result["instructions"], 1)
+}
+
+func TestNotionDoctorApplyRequiresAndUsesApproval(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	specs := notionSpecsSnapshotForTest()
+	delete(specs.Schema, "Tags")
+	data := notionDataForTest(t, specs, notionPlansSnapshotForTest())
+
+	needsApproval, err := runNotionForTest(t, "doctor", "--apply", "--data", data)
+	require.NoError(t, err)
+	require.Equal(t, "approval_required", needsApproval["status"])
+	require.Equal(t, true, needsApproval["approval_required"])
+
+	applied, err := runNotionForTest(t, "doctor", "--apply", "--approve-additive", "--data", data)
+	require.NoError(t, err)
+	require.Equal(t, "repairs_prepared", applied["status"])
+	require.Len(t, applied["applied_repairs"], 1)
+	reportAfter := applied["report_after"].(map[string]any)
+	require.Equal(t, true, reportAfter["valid"])
+}
+
+func TestNotionLink_AcceptsSnapshotFiles(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	specsPath := filepath.Join(dir, "specs.json")
+	plansPath := filepath.Join(dir, "plans.json")
+	specsRaw, err := json.Marshal(notionSpecsSnapshotForTest())
+	require.NoError(t, err)
+	plansRaw, err := json.Marshal(notionPlansSnapshotForTest())
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(specsPath, specsRaw, 0o644))
+	require.NoError(t, os.WriteFile(plansPath, plansRaw, 0o644))
+
+	result, err := runNotionForTest(t, "link", "--specs-file", specsPath, "--plans-file", plansPath, "--data", `{"base_page_url":"https://notion.example/base"}`)
+	require.NoError(t, err)
+	require.Equal(t, "linked", result["status"])
+}

--- a/cmd/notion_workflow_test.go
+++ b/cmd/notion_workflow_test.go
@@ -1,0 +1,167 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jumppad-labs/spektacular/internal/artifact"
+	"github.com/jumppad-labs/spektacular/internal/config"
+	"github.com/jumppad-labs/spektacular/internal/store"
+	"github.com/stretchr/testify/require"
+)
+
+func remoteForWorkflow(kind, id, version string) artifact.RemoteMetadata {
+	return artifact.RemoteMetadata{
+		NotionURL:     "https://notion.so/" + kind + "/" + id,
+		PageID:        kind + "-page-" + id,
+		DataSourceURL: "collection://" + kind,
+		ExternalID:    id,
+		RemoteVersion: version,
+		Title:         id,
+	}
+}
+
+func TestSpecNew_NotionUsesRemoteSpecIDAndCreatesCacheEntry(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeNotionCacheConfig(t, dir)
+
+	result, err := runSpecNewForTest(t, "--data", cacheData(t, map[string]any{
+		"name":   "Billing",
+		"remote": remoteForWorkflow("specs", "SPEC-1", "v1"),
+	}))
+	require.NoError(t, err)
+
+	require.Equal(t, "spec-1-billing", result.SpecName)
+	require.Contains(t, result.SpecPath, filepath.Join(".spektacular", "cache", "notion", "specs", "spec-1-billing.md"))
+	require.FileExists(t, filepath.Join(dir, ".spektacular", "cache", "notion", "specs", "spec-1-billing.md"))
+
+	manifest, err := artifact.LoadManifest(store.NewFileStore(filepath.Join(dir, ".spektacular")), mustLoadConfig(t, dir))
+	require.NoError(t, err)
+	entry := manifest.Entries[artifact.Key(artifact.KindSpec, "spec-1-billing")]
+	require.Equal(t, "SPEC-1", entry.ExternalID)
+	require.Equal(t, "v1", entry.RemoteVersion)
+}
+
+func TestPlanWorkflow_NotionWritesPlanContextResearchCacheEntries(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeNotionCacheConfig(t, dir)
+	name := "plan-1-billing"
+
+	runPlanCommand(t, "new", "--data", cacheData(t, map[string]any{"name": name}))
+	for _, step := range []string{
+		"discovery",
+		"architecture",
+		"components",
+		"data_structures",
+		"implementation_detail",
+		"dependencies",
+		"testing_approach",
+		"milestones",
+		"phases",
+		"open_questions",
+		"out_of_scope",
+		"verification",
+	} {
+		runPlanCommand(t, "goto", "--data", cacheData(t, map[string]any{"step": step}))
+	}
+	runPlanCommand(t, "goto", "--data", cacheData(t, map[string]any{
+		"step":          "write_plan",
+		"plan_template": "# Plan",
+		"remote":        remoteForWorkflow("plans", "PLAN-1", "v1"),
+	}))
+	runPlanCommand(t, "goto", "--data", cacheData(t, map[string]any{
+		"step":             "write_context",
+		"context_template": "# Context",
+		"context_remote":   remoteForWorkflow("plans", "CTX-1", "v1"),
+	}))
+	runPlanCommand(t, "goto", "--data", cacheData(t, map[string]any{
+		"step":              "write_research",
+		"research_template": "# Research",
+		"research_remote":   remoteForWorkflow("plans", "RSH-1", "v1"),
+	}))
+
+	require.FileExists(t, filepath.Join(dir, ".spektacular", "cache", "notion", "plans", name, "plan.md"))
+	require.FileExists(t, filepath.Join(dir, ".spektacular", "cache", "notion", "plans", name, "context.md"))
+	require.FileExists(t, filepath.Join(dir, ".spektacular", "cache", "notion", "plans", name, "research.md"))
+	require.NoFileExists(t, filepath.Join(dir, ".spektacular", "plans", name, "plan.md"))
+
+	manifest, err := artifact.LoadManifest(store.NewFileStore(filepath.Join(dir, ".spektacular")), mustLoadConfig(t, dir))
+	require.NoError(t, err)
+	require.Equal(t, "PLAN-1", manifest.Entries[artifact.Key(artifact.KindPlan, name)].ExternalID)
+	require.Equal(t, "CTX-1", manifest.Entries[artifact.Key(artifact.KindContext, name)].ExternalID)
+	require.Equal(t, "RSH-1", manifest.Entries[artifact.Key(artifact.KindResearch, name)].ExternalID)
+}
+
+func TestImplementNew_NotionRequiresCachedPlan(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeNotionCacheConfig(t, dir)
+	resetImplementCommandFlags(t)
+	setupImplementCmd(t)
+	rootCmd.SetArgs([]string{"implement", "new", "--data", `{"name":"missing"}`})
+	err := rootCmd.Execute()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "plan file not found")
+
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".spektacular", "cache", "notion", "plans", "cached"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".spektacular", "cache", "notion", "plans", "cached", "plan.md"), []byte("# Plan"), 0o644))
+	resetImplementCommandFlags(t)
+	stdout, _ := setupImplementCmd(t)
+	rootCmd.SetArgs([]string{"implement", "new", "--data", `{"name":"cached"}`})
+	require.NoError(t, rootCmd.Execute())
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &result))
+	require.Equal(t, "read_plan", result["step"])
+	require.Contains(t, result["plan_path"], filepath.Join(".spektacular", "cache", "notion", "plans", "cached", "plan.md"))
+}
+
+func resetImplementCommandFlags(t *testing.T) {
+	t.Helper()
+	reset := func() {
+		require.NoError(t, implementCmd.PersistentFlags().Set("schema", "false"))
+		require.NoError(t, implementCmd.PersistentFlags().Set("dry-run", "false"))
+		require.NoError(t, implementNewCmd.Flags().Set("data", ""))
+		require.NoError(t, implementGotoCmd.Flags().Set("data", ""))
+	}
+	reset()
+	t.Cleanup(reset)
+}
+
+func runPlanCommand(t *testing.T, args ...string) map[string]any {
+	t.Helper()
+	resetPlanCommandFlags(t)
+	stdout, _ := setupImplementCmd(t)
+	rootCmd.SetArgs(append([]string{"plan"}, args...))
+	require.NoError(t, rootCmd.Execute())
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &result))
+	return result
+}
+
+func resetPlanCommandFlags(t *testing.T) {
+	t.Helper()
+	reset := func() {
+		require.NoError(t, planCmd.PersistentFlags().Set("schema", "false"))
+		require.NoError(t, planCmd.PersistentFlags().Set("dry-run", "false"))
+		require.NoError(t, planNewCmd.Flags().Set("data", ""))
+		require.NoError(t, planNewCmd.Flags().Set("stdin", ""))
+		require.NoError(t, planNewCmd.Flags().Set("file", ""))
+		require.NoError(t, planGotoCmd.Flags().Set("data", ""))
+		require.NoError(t, planGotoCmd.Flags().Set("stdin", ""))
+		require.NoError(t, planGotoCmd.Flags().Set("file", ""))
+	}
+	reset()
+	t.Cleanup(reset)
+}
+
+func mustLoadConfig(t *testing.T, dir string) config.Config {
+	t.Helper()
+	cfg, err := config.FromYAMLFile(filepath.Join(dir, ".spektacular", "config.yaml"))
+	require.NoError(t, err)
+	return cfg
+}

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/jumppad-labs/spektacular/internal/artifact"
+	"github.com/jumppad-labs/spektacular/internal/config"
 	"github.com/jumppad-labs/spektacular/internal/output"
 	"github.com/jumppad-labs/spektacular/internal/steps/plan"
 	"github.com/jumppad-labs/spektacular/internal/store"
@@ -87,7 +89,10 @@ func runPlanNew(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("--data is required (e.g. --data '{\"name\":\"my-feature\"}')")
 	}
 	var input struct {
-		Name string `json:"name"`
+		Name           string                  `json:"name"`
+		Remote         artifact.RemoteMetadata `json:"remote"`
+		ContextRemote  artifact.RemoteMetadata `json:"context_remote"`
+		ResearchRemote artifact.RemoteMetadata `json:"research_remote"`
 	}
 	if err := json.Unmarshal([]byte(dataStr), &input); err != nil {
 		return fmt.Errorf("parsing --data: %w", err)
@@ -112,11 +117,22 @@ func runPlanNew(cmd *cobra.Command, _ []string) error {
 		_ = os.Remove(statePath)
 	}
 
-	wfCfg := workflow.Config{Command: cfg.Command, DryRun: dryRun}
+	wfCfg := workflow.Config{Command: cfg.Command, DryRun: dryRun, Project: cfg}
 	steps := plan.Steps()
 	out := output.New(cmd.OutOrStdout(), globalFields)
 	wf := workflow.New(steps, statePath, wfCfg, store.NewFileStore(dataDir), out)
 	wf.SetData("name", input.Name)
+	if cfg.Artifacts.Backend == config.ArtifactBackendNotion {
+		if input.Remote.RemoteVersion != "" {
+			wf.SetData("remote", input.Remote)
+		}
+		if input.ContextRemote.RemoteVersion != "" {
+			wf.SetData("context_remote", input.ContextRemote)
+		}
+		if input.ResearchRemote.RemoteVersion != "" {
+			wf.SetData("research_remote", input.ResearchRemote)
+		}
+	}
 
 	if err := readInputIntoWorkflow(cmd, wf); err != nil {
 		return err
@@ -167,7 +183,7 @@ func runPlanGoto(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	wfCfg := workflow.Config{Command: cfg.Command, DryRun: dryRun}
+	wfCfg := workflow.Config{Command: cfg.Command, DryRun: dryRun, Project: cfg}
 	steps := plan.Steps()
 	out := output.New(cmd.OutOrStdout(), globalFields)
 	wf := workflow.New(steps, stateFilePath(dataDir), wfCfg, store.NewFileStore(dataDir), out)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,15 +27,22 @@ func Execute() {
 	}
 }
 
+func configFilePath() (string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("getting working directory: %w", err)
+	}
+	return filepath.Join(cwd, ".spektacular", "config.yaml"), nil
+}
+
 // loadConfig loads the project config from the current working directory.
 // Returns defaults if the config file does not exist.
 // Returns an error if the config file exists but is invalid.
 func loadConfig() (config.Config, error) {
-	cwd, err := os.Getwd()
+	cfgPath, err := configFilePath()
 	if err != nil {
-		return config.Config{}, fmt.Errorf("getting working directory: %w", err)
+		return config.Config{}, err
 	}
-	cfgPath := filepath.Join(cwd, ".spektacular", "config.yaml")
 	if _, err := os.Stat(cfgPath); os.IsNotExist(err) {
 		return config.NewDefault(), nil
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -66,4 +66,5 @@ func init() {
 	rootCmd.AddCommand(implementCmd)
 	rootCmd.AddCommand(skillCmd)
 	rootCmd.AddCommand(initCmd)
+	rootCmd.AddCommand(notionCmd)
 }

--- a/cmd/spec.go
+++ b/cmd/spec.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jumppad-labs/spektacular/internal/artifact"
+	"github.com/jumppad-labs/spektacular/internal/config"
 	"github.com/jumppad-labs/spektacular/internal/output"
 	"github.com/jumppad-labs/spektacular/internal/steps/spec"
 	"github.com/jumppad-labs/spektacular/internal/store"
@@ -167,8 +169,9 @@ func runSpecNew(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("--data is required (e.g. --data '{\"name\":\"my-feature\"}')")
 	}
 	var input struct {
-		Name string `json:"name"`
-		ID   string `json:"id"`
+		Name   string                  `json:"name"`
+		ID     string                  `json:"id"`
+		Remote artifact.RemoteMetadata `json:"remote"`
 	}
 	if err := json.Unmarshal([]byte(dataStr), &input); err != nil {
 		return fmt.Errorf("parsing --data: %w", err)
@@ -181,6 +184,14 @@ func runSpecNew(cmd *cobra.Command, _ []string) error {
 	cfg, err := loadConfig()
 	if err != nil {
 		return err
+	}
+	if cfg.Artifacts.Backend == config.ArtifactBackendNotion {
+		if err := artifact.ValidateRemoteMetadata(input.Remote); err != nil {
+			return err
+		}
+		if input.ID == "" {
+			input.ID = input.Remote.ExternalID
+		}
 	}
 
 	st := store.NewFileStore(dataDir)
@@ -219,7 +230,7 @@ func runSpecNew(cmd *cobra.Command, _ []string) error {
 		_ = os.Remove(statePath)
 	}
 
-	wfCfg := workflow.Config{Command: cfg.Command, DryRun: dryRun}
+	wfCfg := workflow.Config{Command: cfg.Command, DryRun: dryRun, Project: cfg}
 	steps := spec.Steps()
 	out := output.New(cmd.OutOrStdout(), globalFields)
 	wf := workflow.New(steps, statePath, wfCfg, st, out)
@@ -229,6 +240,9 @@ func runSpecNew(cmd *cobra.Command, _ []string) error {
 		}
 	}
 	wf.SetData("name", resolved.Name)
+	if cfg.Artifacts.Backend == config.ArtifactBackendNotion {
+		wf.SetData("remote", input.Remote)
+	}
 
 	if err := wf.Next(); err != nil {
 		return output.WriteError(cmd.ErrOrStderr(), err)
@@ -275,7 +289,7 @@ func runSpecGoto(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	wfCfg := workflow.Config{Command: cfg.Command, DryRun: dryRun}
+	wfCfg := workflow.Config{Command: cfg.Command, DryRun: dryRun, Project: cfg}
 	steps := spec.Steps()
 	out := output.New(cmd.OutOrStdout(), globalFields)
 	wf := workflow.New(steps, stateFilePath(dataDir), wfCfg, store.NewFileStore(dataDir), out)

--- a/cmd/spec.go
+++ b/cmd/spec.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/jumppad-labs/spektacular/internal/output"
 	"github.com/jumppad-labs/spektacular/internal/steps/spec"
@@ -17,6 +18,10 @@ import (
 )
 
 var nameRegexp = regexp.MustCompile(`^[a-z0-9_-]+$`)
+
+const identifierInputPattern = `^[^\s/\\\x00-\x1F\x7F](?:[^/\\\x00-\x1F\x7F]*[^\s/\\\x00-\x1F\x7F])?$`
+
+var specIdentifierNow = time.Now
 
 // Schema types for --schema output.
 type schemaProp struct {
@@ -94,6 +99,12 @@ func stateFilePath(dataDir string) string {
 	return filepath.Join(dataDir, "state.json")
 }
 
+type workflowDataBuffer map[string]any
+
+func (b workflowDataBuffer) SetData(key string, value any) {
+	b[key] = value
+}
+
 // readInputIntoWorkflow reads content from either --stdin or --file and stores
 // it in the workflow data. --stdin <key> reads from standard input and stores
 // under <key>. --file <path> reads the file at <path> (relative paths resolve
@@ -139,7 +150,8 @@ func runSpecNew(cmd *cobra.Command, _ []string) error {
 			Input: &schemaObj{
 				Type: "object",
 				Properties: map[string]*schemaProp{
-					"name": {Type: "string", Pattern: "^[a-z0-9_-]+$", MaxLen: 64},
+					"name": {Type: "string", Pattern: identifierInputPattern, MaxLen: spec.MaxIdentifierPartLength},
+					"id":   {Type: "string", Pattern: identifierInputPattern, MaxLen: spec.MaxIdentifierPartLength},
 				},
 				Required: []string{"name"},
 			},
@@ -156,12 +168,10 @@ func runSpecNew(cmd *cobra.Command, _ []string) error {
 	}
 	var input struct {
 		Name string `json:"name"`
+		ID   string `json:"id"`
 	}
 	if err := json.Unmarshal([]byte(dataStr), &input); err != nil {
 		return fmt.Errorf("parsing --data: %w", err)
-	}
-	if input.Name == "" || !nameRegexp.MatchString(input.Name) || len(input.Name) > 64 {
-		return fmt.Errorf("name must match ^[a-z0-9_-]+$ and be at most 64 characters")
 	}
 
 	dataDir, err := dataDir()
@@ -171,6 +181,35 @@ func runSpecNew(cmd *cobra.Command, _ []string) error {
 	cfg, err := loadConfig()
 	if err != nil {
 		return err
+	}
+
+	st := store.NewFileStore(dataDir)
+	extraData := workflowDataBuffer{}
+	if err := readInputIntoWorkflow(cmd, extraData); err != nil {
+		return err
+	}
+
+	resolved, err := spec.ResolveIdentifier(spec.IdentifierRequest{
+		Name:    input.Name,
+		ID:      input.ID,
+		Method:  cfg.Spec.IDMethod,
+		Counter: cfg.Spec.Counter,
+		Store:   st,
+		Now:     specIdentifierNow,
+	})
+	if err != nil {
+		return err
+	}
+
+	if !dryRun && resolved.Counter != cfg.Spec.Counter {
+		cfg.Spec.Counter = resolved.Counter
+		cfgPath, err := configFilePath()
+		if err != nil {
+			return err
+		}
+		if err := cfg.ToYAMLFile(cfgPath); err != nil {
+			return fmt.Errorf("writing config: %w", err)
+		}
 	}
 
 	statePath := stateFilePath(dataDir)
@@ -183,12 +222,13 @@ func runSpecNew(cmd *cobra.Command, _ []string) error {
 	wfCfg := workflow.Config{Command: cfg.Command, DryRun: dryRun}
 	steps := spec.Steps()
 	out := output.New(cmd.OutOrStdout(), globalFields)
-	wf := workflow.New(steps, statePath, wfCfg, store.NewFileStore(dataDir), out)
-	wf.SetData("name", input.Name)
-
-	if err := readInputIntoWorkflow(cmd, wf); err != nil {
-		return err
+	wf := workflow.New(steps, statePath, wfCfg, st, out)
+	for k, v := range extraData {
+		if k != "name" {
+			wf.SetData(k, v)
+		}
 	}
+	wf.SetData("name", resolved.Name)
 
 	if err := wf.Next(); err != nil {
 		return output.WriteError(cmd.ErrOrStderr(), err)

--- a/cmd/spec_test.go
+++ b/cmd/spec_test.go
@@ -1,0 +1,271 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/jumppad-labs/spektacular/internal/config"
+	"github.com/jumppad-labs/spektacular/internal/steps/spec"
+	"github.com/stretchr/testify/require"
+)
+
+type specCommandResult struct {
+	Step        string `json:"step"`
+	SpecPath    string `json:"spec_path"`
+	SpecName    string `json:"spec_name"`
+	Instruction string `json:"instruction"`
+}
+
+func writeSpecCommandConfig(t *testing.T, dir, body string) {
+	t.Helper()
+	dataDir := filepath.Join(dir, ".spektacular")
+	require.NoError(t, os.MkdirAll(dataDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dataDir, "config.yaml"), []byte(body), 0o644))
+}
+
+func writeSpecCommandFile(t *testing.T, dir, name string) {
+	t.Helper()
+	path := filepath.Join(dir, ".spektacular", "specs", name+".md")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte("existing"), 0o644))
+}
+
+func resetSpecCommandFlags(t *testing.T) {
+	t.Helper()
+	reset := func() {
+		require.NoError(t, specCmd.PersistentFlags().Set("schema", "false"))
+		require.NoError(t, specCmd.PersistentFlags().Set("dry-run", "false"))
+		require.NoError(t, specNewCmd.Flags().Set("data", ""))
+		require.NoError(t, specNewCmd.Flags().Set("stdin", ""))
+		require.NoError(t, specNewCmd.Flags().Set("file", ""))
+	}
+	reset()
+	t.Cleanup(reset)
+}
+
+func setSpecIdentifierNow(t *testing.T, now time.Time) {
+	t.Helper()
+	original := specIdentifierNow
+	specIdentifierNow = func() time.Time { return now }
+	t.Cleanup(func() {
+		specIdentifierNow = original
+	})
+}
+
+func runSpecNewForTest(t *testing.T, args ...string) (specCommandResult, error) {
+	t.Helper()
+	resetSpecCommandFlags(t)
+	stdout, _ := setupImplementCmd(t)
+	rootCmd.SetArgs(append([]string{"spec", "new"}, args...))
+
+	err := rootCmd.Execute()
+	if err != nil {
+		return specCommandResult{}, err
+	}
+
+	var result specCommandResult
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &result))
+	return result, nil
+}
+
+func runSpecNewSchemaForTest(t *testing.T) commandSchema {
+	t.Helper()
+	resetSpecCommandFlags(t)
+	stdout, _ := setupImplementCmd(t)
+	rootCmd.SetArgs([]string{"spec", "new", "--schema"})
+
+	require.NoError(t, rootCmd.Execute())
+
+	var schema commandSchema
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &schema))
+	return schema
+}
+
+func TestSpecNewSchemaDocumentsNameAndOptionalID(t *testing.T) {
+	schema := runSpecNewSchemaForTest(t)
+
+	require.Contains(t, schema.Input.Properties, "name")
+	require.Contains(t, schema.Input.Properties, "id")
+	require.Equal(t, []string{"name"}, schema.Input.Required)
+	require.Equal(t, spec.MaxIdentifierPartLength, schema.Input.Properties["name"].MaxLen)
+	require.Equal(t, spec.MaxIdentifierPartLength, schema.Input.Properties["id"].MaxLen)
+}
+
+func TestSpecNew_DefaultUsesTimestampPrefix(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	result, err := runSpecNewForTest(t, "--data", `{"name":"Billing.Export"}`)
+	require.NoError(t, err)
+
+	require.Equal(t, "overview", result.Step)
+	require.Regexp(t, regexp.MustCompile(`^\d{14}-billing-export$`), result.SpecName)
+	require.Equal(t, filepath.Join(dir, ".spektacular", "specs", result.SpecName+".md"), result.SpecPath)
+	require.FileExists(t, result.SpecPath)
+}
+
+func TestSpecNew_TimestampCollisionBumpsSeconds(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	setSpecIdentifierNow(t, time.Date(2026, time.May, 9, 1, 2, 3, 0, time.UTC))
+	writeSpecCommandFile(t, dir, "20260509010203-billing-export")
+
+	result, err := runSpecNewForTest(t, "--data", `{"name":"billing-export"}`)
+	require.NoError(t, err)
+
+	require.Equal(t, "20260509010204-billing-export", result.SpecName)
+	require.FileExists(t, filepath.Join(dir, ".spektacular", "specs", "20260509010203-billing-export.md"))
+	require.FileExists(t, result.SpecPath)
+}
+
+func TestSpecNew_ExplicitIDOverridesGeneratedMethod(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeSpecCommandConfig(t, dir, "spec:\n  id_method: counter\n  counter: 7\n")
+
+	result, err := runSpecNewForTest(t, "--data", `{"name":"Billing Export","id":"EXT.User@123"}`)
+	require.NoError(t, err)
+
+	require.Equal(t, "ext-user-123-billing-export", result.SpecName)
+	require.FileExists(t, result.SpecPath)
+
+	cfg, err := config.FromYAMLFile(filepath.Join(dir, ".spektacular", "config.yaml"))
+	require.NoError(t, err)
+	require.Equal(t, 7, cfg.Spec.Counter)
+}
+
+func TestSpecNew_ExternalModeWithIDCreatesSpec(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeSpecCommandConfig(t, dir, "spec:\n  id_method: external\n")
+
+	result, err := runSpecNewForTest(t, "--data", `{"name":"Billing Export","id":"EXT.User@123"}`)
+	require.NoError(t, err)
+
+	require.Equal(t, "ext-user-123-billing-export", result.SpecName)
+	require.FileExists(t, result.SpecPath)
+}
+
+func TestSpecNew_ExternalModeRequiresIDWithoutSideEffects(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	dataDir := filepath.Join(dir, ".spektacular")
+	writeSpecCommandConfig(t, dir, "spec:\n  id_method: external\n")
+
+	_, err := runSpecNewForTest(t, "--data", `{"name":"Billing Export"}`)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "id is required")
+	require.NoDirExists(t, filepath.Join(dataDir, "specs"))
+	require.NoFileExists(t, filepath.Join(dataDir, "state.json"))
+}
+
+func TestSpecNew_CounterModePersistsAdvancedCounter(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeSpecCommandConfig(t, dir, "spec:\n  id_method: counter\n  counter: 7\n")
+
+	result, err := runSpecNewForTest(t, "--data", `{"name":"billing-export"}`)
+	require.NoError(t, err)
+
+	require.Equal(t, "000008-billing-export", result.SpecName)
+	require.FileExists(t, result.SpecPath)
+
+	cfg, err := config.FromYAMLFile(filepath.Join(dir, ".spektacular", "config.yaml"))
+	require.NoError(t, err)
+	require.Equal(t, 8, cfg.Spec.Counter)
+}
+
+func TestSpecNew_StaleCounterCollisionPersistsBumpedCounter(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeSpecCommandConfig(t, dir, "spec:\n  id_method: counter\n  counter: 7\n")
+	writeSpecCommandFile(t, dir, "000008-billing-export")
+
+	result, err := runSpecNewForTest(t, "--data", `{"name":"billing-export"}`)
+	require.NoError(t, err)
+
+	require.Equal(t, "000009-billing-export", result.SpecName)
+	require.FileExists(t, result.SpecPath)
+
+	cfg, err := config.FromYAMLFile(filepath.Join(dir, ".spektacular", "config.yaml"))
+	require.NoError(t, err)
+	require.Equal(t, 9, cfg.Spec.Counter)
+}
+
+func TestSpecNew_DryRunReportsCanonicalNameWithoutWrites(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	dataDir := filepath.Join(dir, ".spektacular")
+	writeSpecCommandConfig(t, dir, "spec:\n  id_method: counter\n  counter: 7\n")
+
+	result, err := runSpecNewForTest(t, "--dry-run", "--data", `{"name":"billing-export"}`)
+	require.NoError(t, err)
+
+	require.Equal(t, "000008-billing-export", result.SpecName)
+	require.Equal(t, filepath.Join(dataDir, "specs", "000008-billing-export.md"), result.SpecPath)
+	require.NoFileExists(t, result.SpecPath)
+	require.NoFileExists(t, filepath.Join(dataDir, "state.json"))
+
+	cfg, err := config.FromYAMLFile(filepath.Join(dataDir, "config.yaml"))
+	require.NoError(t, err)
+	require.Equal(t, 7, cfg.Spec.Counter)
+}
+
+func TestSpecNew_ValidationFailuresLeaveNoSpecOrState(t *testing.T) {
+	tests := []struct {
+		name string
+		data string
+		want string
+	}{
+		{
+			name: "untrimmed name",
+			data: `{"name":" billing"}`,
+			want: "leading or trailing whitespace",
+		},
+		{
+			name: "path separator id",
+			data: `{"name":"billing","id":"bad/id"}`,
+			want: "path separators",
+		},
+		{
+			name: "untrimmed id",
+			data: `{"name":"billing","id":"ext "}`,
+			want: "leading or trailing whitespace",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			t.Chdir(dir)
+			dataDir := filepath.Join(dir, ".spektacular")
+
+			_, err := runSpecNewForTest(t, "--data", tt.data)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.want)
+			require.NoDirExists(t, filepath.Join(dataDir, "specs"))
+			require.NoFileExists(t, filepath.Join(dataDir, "state.json"))
+		})
+	}
+}
+
+func TestSpecNew_RejectsUnknownConfiguredIDMethod(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	dataDir := filepath.Join(dir, ".spektacular")
+	require.NoError(t, os.MkdirAll(dataDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dataDir, "config.yaml"), []byte("spec:\n  id_method: unsupported\n"), 0o644))
+
+	setupImplementCmd(t)
+	rootCmd.SetArgs([]string{"spec", "new", "--data", `{"name":"fixture"}`})
+
+	err := rootCmd.Execute()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "spec.id_method")
+	require.NoFileExists(t, filepath.Join(dataDir, "specs", "fixture.md"))
+	require.NoFileExists(t, filepath.Join(dataDir, "state.json"))
+}

--- a/internal/artifact/artifact.go
+++ b/internal/artifact/artifact.go
@@ -1,0 +1,410 @@
+package artifact
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/jumppad-labs/spektacular/internal/config"
+	"github.com/jumppad-labs/spektacular/internal/store"
+)
+
+const (
+	KindSpec     = "spec"
+	KindPlan     = "plan"
+	KindContext  = "context"
+	KindResearch = "research"
+
+	manifestFilename = "manifest.json"
+)
+
+// RemoteMetadata is the Notion identity and version data recorded on pull.
+type RemoteMetadata struct {
+	NotionURL     string `json:"notion_url"`
+	PageID        string `json:"page_id"`
+	DataSourceURL string `json:"data_source_url"`
+	ExternalID    string `json:"external_id"`
+	RemoteVersion string `json:"remote_version"`
+	Title         string `json:"title,omitempty"`
+}
+
+// RemoteMetadataFromAny decodes metadata that may have round-tripped through workflow JSON state.
+func RemoteMetadataFromAny(value any) (RemoteMetadata, bool, error) {
+	if value == nil {
+		return RemoteMetadata{}, false, nil
+	}
+	switch typed := value.(type) {
+	case RemoteMetadata:
+		return typed, true, nil
+	case map[string]any:
+		raw, err := json.Marshal(typed)
+		if err != nil {
+			return RemoteMetadata{}, true, err
+		}
+		var remote RemoteMetadata
+		if err := json.Unmarshal(raw, &remote); err != nil {
+			return RemoteMetadata{}, true, err
+		}
+		return remote, true, nil
+	default:
+		raw, err := json.Marshal(typed)
+		if err != nil {
+			return RemoteMetadata{}, true, err
+		}
+		var remote RemoteMetadata
+		if err := json.Unmarshal(raw, &remote); err != nil {
+			return RemoteMetadata{}, true, err
+		}
+		return remote, true, nil
+	}
+}
+
+// ValidateRemoteMetadata checks the normalized Notion MCP metadata fields.
+func ValidateRemoteMetadata(remote RemoteMetadata) error {
+	switch {
+	case remote.NotionURL == "":
+		return fmt.Errorf("remote.notion_url is required")
+	case remote.PageID == "":
+		return fmt.Errorf("remote.page_id is required")
+	case remote.DataSourceURL == "":
+		return fmt.Errorf("remote.data_source_url is required")
+	case remote.ExternalID == "":
+		return fmt.Errorf("remote.external_id is required")
+	case remote.RemoteVersion == "":
+		return fmt.Errorf("remote.remote_version is required")
+	default:
+		return nil
+	}
+}
+
+// Entry is one cached artifact tracked by the Notion manifest.
+type Entry struct {
+	Kind          string `json:"kind"`
+	Name          string `json:"name"`
+	LocalPath     string `json:"local_path"`
+	BaselinePath  string `json:"baseline_path"`
+	Checksum      string `json:"checksum"`
+	NotionURL     string `json:"notion_url"`
+	PageID        string `json:"page_id"`
+	DataSourceURL string `json:"data_source_url"`
+	ExternalID    string `json:"external_id"`
+	RemoteVersion string `json:"remote_version"`
+	Title         string `json:"title,omitempty"`
+}
+
+// Manifest stores cached artifact metadata for Notion-backed projects.
+type Manifest struct {
+	Version int              `json:"version"`
+	Entries map[string]Entry `json:"entries"`
+}
+
+// Identity locates a cached artifact using Notion or Spektacular identifiers.
+type Identity struct {
+	Kind       string
+	NotionURL  string
+	PageID     string
+	ExternalID string
+}
+
+// Status reports whether a cached artifact differs from its pulled baseline.
+type Status struct {
+	Entry           Entry  `json:"entry"`
+	Exists          bool   `json:"exists"`
+	Dirty           bool   `json:"dirty"`
+	Stale           bool   `json:"stale"`
+	CurrentChecksum string `json:"current_checksum,omitempty"`
+	RemoteVersion   string `json:"remote_version,omitempty"`
+}
+
+// Checksum returns the stable SHA-256 checksum for content.
+func Checksum(content []byte) string {
+	sum := sha256.Sum256(content)
+	return hex.EncodeToString(sum[:])
+}
+
+// Path resolves the store-relative path for an artifact in the configured backend.
+func Path(cfg config.Config, kind, name string) (string, error) {
+	if err := validateKind(kind); err != nil {
+		return "", err
+	}
+	if err := validateName(name); err != nil {
+		return "", err
+	}
+
+	if cfg.Artifacts.Backend == config.ArtifactBackendNotion {
+		return notionPath(cfg.Artifacts.CacheDir, kind, name), nil
+	}
+	return localPath(kind, name), nil
+}
+
+// ManifestPath returns the store-relative Notion manifest path.
+func ManifestPath(cfg config.Config) string {
+	cacheDir := cfg.Artifacts.CacheDir
+	if cacheDir == "" {
+		cacheDir = config.DefaultNotionCacheDir
+	}
+	return filepath.ToSlash(filepath.Join(cacheDir, manifestFilename))
+}
+
+// LoadManifest reads the Notion artifact manifest. Missing manifests are empty.
+func LoadManifest(st store.Store, cfg config.Config) (Manifest, error) {
+	raw, err := st.Read(ManifestPath(cfg))
+	if err == store.ErrNotFound {
+		return NewManifest(), nil
+	}
+	if err != nil {
+		return Manifest{}, err
+	}
+	var manifest Manifest
+	if err := json.Unmarshal(raw, &manifest); err != nil {
+		return Manifest{}, fmt.Errorf("parsing artifact manifest: %w", err)
+	}
+	if manifest.Version == 0 {
+		manifest.Version = 1
+	}
+	if manifest.Entries == nil {
+		manifest.Entries = map[string]Entry{}
+	}
+	return manifest, nil
+}
+
+// SaveManifest writes the Notion artifact manifest.
+func SaveManifest(st store.Store, cfg config.Config, manifest Manifest) error {
+	if manifest.Version == 0 {
+		manifest.Version = 1
+	}
+	if manifest.Entries == nil {
+		manifest.Entries = map[string]Entry{}
+	}
+	raw, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshalling artifact manifest: %w", err)
+	}
+	return st.Write(ManifestPath(cfg), raw)
+}
+
+// NewManifest returns an empty manifest.
+func NewManifest() Manifest {
+	return Manifest{Version: 1, Entries: map[string]Entry{}}
+}
+
+// RecordPull writes pulled content to cache and records its remote baseline.
+func RecordPull(st store.Store, cfg config.Config, kind, name string, content []byte, remote RemoteMetadata) (Entry, error) {
+	localPath, err := Path(cfg, kind, name)
+	if err != nil {
+		return Entry{}, err
+	}
+	baselinePath, err := BaselinePath(cfg, kind, name)
+	if err != nil {
+		return Entry{}, err
+	}
+	if err := st.Write(localPath, content); err != nil {
+		return Entry{}, err
+	}
+	if err := st.Write(baselinePath, content); err != nil {
+		return Entry{}, err
+	}
+
+	manifest, err := LoadManifest(st, cfg)
+	if err != nil {
+		return Entry{}, err
+	}
+	entry := Entry{
+		Kind:          kind,
+		Name:          name,
+		LocalPath:     localPath,
+		BaselinePath:  baselinePath,
+		Checksum:      Checksum(content),
+		NotionURL:     remote.NotionURL,
+		PageID:        remote.PageID,
+		DataSourceURL: remote.DataSourceURL,
+		ExternalID:    remote.ExternalID,
+		RemoteVersion: remote.RemoteVersion,
+		Title:         remote.Title,
+	}
+	manifest.Entries[Key(kind, name)] = entry
+	if err := SaveManifest(st, cfg, manifest); err != nil {
+		return Entry{}, err
+	}
+	return entry, nil
+}
+
+// UpdateBaseline records content as the clean remote baseline for an entry.
+func UpdateBaseline(st store.Store, cfg config.Config, entry Entry, content []byte, remote RemoteMetadata) (Entry, error) {
+	if entry.BaselinePath == "" {
+		baselinePath, err := BaselinePath(cfg, entry.Kind, entry.Name)
+		if err != nil {
+			return Entry{}, err
+		}
+		entry.BaselinePath = baselinePath
+	}
+	if err := st.Write(entry.BaselinePath, content); err != nil {
+		return Entry{}, err
+	}
+
+	entry.Checksum = Checksum(content)
+	entry.NotionURL = firstNonEmpty(remote.NotionURL, entry.NotionURL)
+	entry.PageID = firstNonEmpty(remote.PageID, entry.PageID)
+	entry.DataSourceURL = firstNonEmpty(remote.DataSourceURL, entry.DataSourceURL)
+	entry.ExternalID = firstNonEmpty(remote.ExternalID, entry.ExternalID)
+	entry.RemoteVersion = firstNonEmpty(remote.RemoteVersion, entry.RemoteVersion)
+	entry.Title = firstNonEmpty(remote.Title, entry.Title)
+
+	manifest, err := LoadManifest(st, cfg)
+	if err != nil {
+		return Entry{}, err
+	}
+	manifest.Entries[Key(entry.Kind, entry.Name)] = entry
+	if err := SaveManifest(st, cfg, manifest); err != nil {
+		return Entry{}, err
+	}
+	return entry, nil
+}
+
+// Find returns the first manifest entry matching the supplied identity.
+func (m Manifest) Find(identity Identity) (Entry, bool) {
+	for _, entry := range m.Entries {
+		if identity.Kind != "" && entry.Kind != identity.Kind {
+			continue
+		}
+		switch {
+		case identity.NotionURL != "" && entry.NotionURL == identity.NotionURL:
+			return entry, true
+		case identity.PageID != "" && entry.PageID == identity.PageID:
+			return entry, true
+		case identity.ExternalID != "" && entry.ExternalID == identity.ExternalID:
+			return entry, true
+		}
+	}
+	return Entry{}, false
+}
+
+// EntryStatus compares the current cache file against the manifest baseline.
+func EntryStatus(st store.Store, entry Entry, currentRemoteVersion string) (Status, error) {
+	status := Status{
+		Entry:         entry,
+		RemoteVersion: currentRemoteVersion,
+		Stale:         currentRemoteVersion != "" && currentRemoteVersion != entry.RemoteVersion,
+	}
+	content, err := st.Read(entry.LocalPath)
+	if err == store.ErrNotFound {
+		return status, nil
+	}
+	if err != nil {
+		return Status{}, err
+	}
+	status.Exists = true
+	status.CurrentChecksum = Checksum(content)
+	status.Dirty = status.CurrentChecksum != entry.Checksum
+	return status, nil
+}
+
+// BaselineContent reads the pulled remote baseline for an entry.
+func BaselineContent(st store.Store, entry Entry) ([]byte, error) {
+	if entry.BaselinePath == "" {
+		return nil, fmt.Errorf("artifact %s is missing baseline path", Key(entry.Kind, entry.Name))
+	}
+	content, err := st.Read(entry.BaselinePath)
+	if err != nil {
+		return nil, err
+	}
+	return content, nil
+}
+
+// Key returns the stable manifest key for an artifact.
+func Key(kind, name string) string {
+	return kind + ":" + name
+}
+
+// BaselinePath resolves the store-relative baseline path for an artifact.
+func BaselinePath(cfg config.Config, kind, name string) (string, error) {
+	if err := validateKind(kind); err != nil {
+		return "", err
+	}
+	if err := validateName(name); err != nil {
+		return "", err
+	}
+	cacheDir := cfg.Artifacts.CacheDir
+	if cacheDir == "" {
+		cacheDir = config.DefaultNotionCacheDir
+	}
+	switch kind {
+	case KindSpec:
+		return filepath.ToSlash(filepath.Join(cacheDir, ".baseline", "specs", name+".md")), nil
+	case KindPlan:
+		return filepath.ToSlash(filepath.Join(cacheDir, ".baseline", "plans", name, "plan.md")), nil
+	case KindContext:
+		return filepath.ToSlash(filepath.Join(cacheDir, ".baseline", "plans", name, "context.md")), nil
+	case KindResearch:
+		return filepath.ToSlash(filepath.Join(cacheDir, ".baseline", "plans", name, "research.md")), nil
+	default:
+		return "", fmt.Errorf("unsupported artifact kind %q", kind)
+	}
+}
+
+func notionPath(cacheDir, kind, name string) string {
+	if cacheDir == "" {
+		cacheDir = config.DefaultNotionCacheDir
+	}
+	switch kind {
+	case KindSpec:
+		return filepath.ToSlash(filepath.Join(cacheDir, "specs", name+".md"))
+	case KindPlan:
+		return filepath.ToSlash(filepath.Join(cacheDir, "plans", name, "plan.md"))
+	case KindContext:
+		return filepath.ToSlash(filepath.Join(cacheDir, "plans", name, "context.md"))
+	case KindResearch:
+		return filepath.ToSlash(filepath.Join(cacheDir, "plans", name, "research.md"))
+	default:
+		return ""
+	}
+}
+
+func localPath(kind, name string) string {
+	switch kind {
+	case KindSpec:
+		return filepath.ToSlash(filepath.Join("specs", name+".md"))
+	case KindPlan:
+		return filepath.ToSlash(filepath.Join("plans", name, "plan.md"))
+	case KindContext:
+		return filepath.ToSlash(filepath.Join("plans", name, "context.md"))
+	case KindResearch:
+		return filepath.ToSlash(filepath.Join("plans", name, "research.md"))
+	default:
+		return ""
+	}
+}
+
+func validateKind(kind string) error {
+	switch kind {
+	case KindSpec, KindPlan, KindContext, KindResearch:
+		return nil
+	default:
+		return fmt.Errorf("unsupported artifact kind %q", kind)
+	}
+}
+
+func validateName(name string) error {
+	if name == "" {
+		return fmt.Errorf("artifact name is required")
+	}
+	if strings.ContainsAny(name, `/\`) {
+		return fmt.Errorf("artifact name must not contain path separators")
+	}
+	if name == "." || name == ".." {
+		return fmt.Errorf("artifact name must not be %q", name)
+	}
+	return nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/artifact/artifact_test.go
+++ b/internal/artifact/artifact_test.go
@@ -1,0 +1,148 @@
+package artifact
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/jumppad-labs/spektacular/internal/config"
+	"github.com/jumppad-labs/spektacular/internal/store"
+	"github.com/stretchr/testify/require"
+)
+
+func notionConfigForTest() config.Config {
+	cfg := config.NewDefault()
+	cfg.Spec.IDMethod = config.SpecIDMethodExternal
+	cfg.Artifacts.Backend = config.ArtifactBackendNotion
+	cfg.Artifacts.Notion.SpecsDataSource = "collection://specs"
+	cfg.Artifacts.Notion.PlansDataSource = "collection://plans"
+	return cfg
+}
+
+func remoteForTest() RemoteMetadata {
+	return RemoteMetadata{
+		NotionURL:     "https://notion.so/spec",
+		PageID:        "page-123",
+		DataSourceURL: "collection://specs",
+		ExternalID:    "SPEC-1",
+		RemoteVersion: "2026-05-09T12:00:00Z",
+		Title:         "Billing Export",
+	}
+}
+
+func TestPath_NotionArtifactsResolveOutsideLocalArtifactDirectories(t *testing.T) {
+	cfg := notionConfigForTest()
+
+	specPath, err := Path(cfg, KindSpec, "20260509-billing")
+	require.NoError(t, err)
+	planPath, err := Path(cfg, KindPlan, "20260509-billing")
+	require.NoError(t, err)
+
+	require.Equal(t, "cache/notion/specs/20260509-billing.md", specPath)
+	require.Equal(t, "cache/notion/plans/20260509-billing/plan.md", planPath)
+	require.NotEqual(t, "specs/20260509-billing.md", specPath)
+	require.NotEqual(t, "plans/20260509-billing/plan.md", planPath)
+}
+
+func TestPath_LocalArtifactsKeepExistingLocations(t *testing.T) {
+	cfg := config.NewDefault()
+
+	specPath, err := Path(cfg, KindSpec, "20260509-billing")
+	require.NoError(t, err)
+	planPath, err := Path(cfg, KindPlan, "20260509-billing")
+	require.NoError(t, err)
+
+	require.Equal(t, "specs/20260509-billing.md", specPath)
+	require.Equal(t, "plans/20260509-billing/plan.md", planPath)
+}
+
+func TestRecordPullWritesCacheAndManifestMetadata(t *testing.T) {
+	cfg := notionConfigForTest()
+	st := store.NewFileStore(t.TempDir())
+	content := []byte("# Spec\n")
+
+	entry, err := RecordPull(st, cfg, KindSpec, "spec-1", content, remoteForTest())
+	require.NoError(t, err)
+
+	require.Equal(t, "cache/notion/specs/spec-1.md", entry.LocalPath)
+	require.Equal(t, Checksum(content), entry.Checksum)
+	require.Equal(t, "https://notion.so/spec", entry.NotionURL)
+	require.Equal(t, "page-123", entry.PageID)
+	require.Equal(t, "collection://specs", entry.DataSourceURL)
+	require.Equal(t, "SPEC-1", entry.ExternalID)
+	require.Equal(t, "2026-05-09T12:00:00Z", entry.RemoteVersion)
+
+	cached, err := st.Read(entry.LocalPath)
+	require.NoError(t, err)
+	require.Equal(t, content, cached)
+
+	manifest, err := LoadManifest(st, cfg)
+	require.NoError(t, err)
+	require.Equal(t, entry, manifest.Entries[Key(KindSpec, "spec-1")])
+}
+
+func TestManifestFindLocatesByNotionAndExternalIdentity(t *testing.T) {
+	manifest := NewManifest()
+	entry := Entry{
+		Kind:       KindSpec,
+		Name:       "spec-1",
+		NotionURL:  "https://notion.so/spec",
+		PageID:     "page-123",
+		ExternalID: "SPEC-1",
+	}
+	manifest.Entries[Key(entry.Kind, entry.Name)] = entry
+
+	for _, identity := range []Identity{
+		{NotionURL: "https://notion.so/spec"},
+		{PageID: "page-123"},
+		{Kind: KindSpec, ExternalID: "SPEC-1"},
+	} {
+		got, ok := manifest.Find(identity)
+		require.True(t, ok)
+		require.Equal(t, entry, got)
+	}
+
+	_, ok := manifest.Find(Identity{Kind: KindPlan, ExternalID: "SPEC-1"})
+	require.False(t, ok)
+}
+
+func TestEntryStatusDetectsDirtyAndStaleWithoutChangingBaseline(t *testing.T) {
+	cfg := notionConfigForTest()
+	st := store.NewFileStore(t.TempDir())
+	entry, err := RecordPull(st, cfg, KindSpec, "spec-1", []byte("baseline"), remoteForTest())
+	require.NoError(t, err)
+	require.NoError(t, st.Write(entry.LocalPath, []byte("edited")))
+
+	status, err := EntryStatus(st, entry, "2026-05-09T12:30:00Z")
+	require.NoError(t, err)
+
+	require.True(t, status.Exists)
+	require.True(t, status.Dirty)
+	require.True(t, status.Stale)
+	require.Equal(t, Checksum([]byte("baseline")), entry.Checksum)
+	require.Equal(t, "2026-05-09T12:00:00Z", entry.RemoteVersion)
+	require.Equal(t, Checksum([]byte("edited")), status.CurrentChecksum)
+}
+
+func TestPathRejectsTraversalNames(t *testing.T) {
+	cfg := notionConfigForTest()
+
+	_, err := Path(cfg, KindSpec, "../escape")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "path separators")
+
+	_, err = Path(cfg, "unknown", "spec")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unsupported artifact kind")
+}
+
+func TestSaveManifestUsesCachePath(t *testing.T) {
+	cfg := notionConfigForTest()
+	root := t.TempDir()
+	st := store.NewFileStore(root)
+
+	manifest := NewManifest()
+	manifest.Entries[Key(KindPlan, "plan-1")] = Entry{Kind: KindPlan, Name: "plan-1"}
+	require.NoError(t, SaveManifest(st, cfg, manifest))
+
+	require.FileExists(t, filepath.Join(root, "cache", "notion", "manifest.json"))
+}

--- a/internal/artifact/sync/sync.go
+++ b/internal/artifact/sync/sync.go
@@ -1,0 +1,265 @@
+package sync
+
+import (
+	"fmt"
+
+	"github.com/jumppad-labs/spektacular/internal/artifact"
+	"github.com/jumppad-labs/spektacular/internal/config"
+	"github.com/jumppad-labs/spektacular/internal/store"
+)
+
+const (
+	StatusPulled        = "pulled"
+	StatusReady         = "ready"
+	StatusClean         = "clean"
+	StatusMergeRequired = "merge_required"
+	StatusCommitted     = "committed"
+	StatusResolved      = "resolved"
+)
+
+// PullRequest records content and remote metadata fetched through Notion MCP.
+type PullRequest struct {
+	Kind    string                  `json:"kind"`
+	Name    string                  `json:"name"`
+	Content string                  `json:"content"`
+	Remote  artifact.RemoteMetadata `json:"remote"`
+}
+
+// IdentityRequest locates an existing cached artifact.
+type IdentityRequest struct {
+	Kind       string `json:"kind"`
+	Name       string `json:"name"`
+	NotionURL  string `json:"notion_url"`
+	PageID     string `json:"page_id"`
+	ExternalID string `json:"external_id"`
+}
+
+// PushRequest prepares a local artifact for a Notion MCP update.
+type PushRequest struct {
+	IdentityRequest
+	RemoteVersion string `json:"remote_version"`
+	RemoteContent string `json:"remote_content"`
+}
+
+// CommitRequest records metadata returned after a successful Notion MCP update.
+type CommitRequest struct {
+	IdentityRequest
+	Remote artifact.RemoteMetadata `json:"remote"`
+}
+
+// MergeRequestInput records a completed user/agent merge.
+type MergeRequestInput struct {
+	IdentityRequest
+	Remote          artifact.RemoteMetadata `json:"remote"`
+	RemoteContent   string                  `json:"remote_content"`
+	ResolvedContent string                  `json:"resolved_content"`
+}
+
+// Result is the structured sync contract returned by cache commands.
+type Result struct {
+	Status       string          `json:"status"`
+	Entry        artifact.Entry  `json:"entry,omitempty"`
+	LocalPath    string          `json:"local_path,omitempty"`
+	LocalContent string          `json:"local_content,omitempty"`
+	StatusDetail artifact.Status `json:"status_detail,omitempty"`
+	MergeRequest *MergeRequest   `json:"merge_request,omitempty"`
+	Changed      bool            `json:"changed,omitempty"`
+	Next         string          `json:"next,omitempty"`
+}
+
+// MergeRequest contains all content needed to resolve a stale remote safely.
+type MergeRequest struct {
+	Kind            string `json:"kind"`
+	Name            string `json:"name"`
+	LocalPath       string `json:"local_path"`
+	NotionURL       string `json:"notion_url"`
+	PageID          string `json:"page_id"`
+	ExternalID      string `json:"external_id"`
+	BaselineVersion string `json:"baseline_version"`
+	RemoteVersion   string `json:"remote_version"`
+	BaselineContent string `json:"baseline_content"`
+	LocalContent    string `json:"local_content"`
+	RemoteContent   string `json:"remote_content"`
+	RequiredAction  string `json:"required_action"`
+}
+
+// Pull writes fetched content to the cache and records its manifest baseline.
+func Pull(st store.Store, cfg config.Config, req PullRequest) (Result, error) {
+	if err := validateRemote(req.Remote); err != nil {
+		return Result{}, err
+	}
+	if req.Kind == "" || req.Name == "" {
+		return Result{}, fmt.Errorf("kind and name are required")
+	}
+	entry, err := artifact.RecordPull(st, cfg, req.Kind, req.Name, []byte(req.Content), req.Remote)
+	if err != nil {
+		return Result{}, err
+	}
+	return Result{
+		Status:    StatusPulled,
+		Entry:     entry,
+		LocalPath: entry.LocalPath,
+		Changed:   true,
+		Next:      "Edit the local cache file, then run prepare-push before updating Notion.",
+	}, nil
+}
+
+// Status returns the dirty/stale status for a cached artifact.
+func Status(st store.Store, cfg config.Config, req PushRequest) (Result, error) {
+	entry, err := lookupEntry(st, cfg, req.IdentityRequest)
+	if err != nil {
+		return Result{}, err
+	}
+	status, err := artifact.EntryStatus(st, entry, req.RemoteVersion)
+	if err != nil {
+		return Result{}, err
+	}
+	return Result{Status: "status", Entry: entry, LocalPath: entry.LocalPath, StatusDetail: status}, nil
+}
+
+// PreparePush decides whether a local edit can be safely pushed to Notion.
+func PreparePush(st store.Store, cfg config.Config, req PushRequest) (Result, error) {
+	entry, err := lookupEntry(st, cfg, req.IdentityRequest)
+	if err != nil {
+		return Result{}, err
+	}
+	status, err := artifact.EntryStatus(st, entry, req.RemoteVersion)
+	if err != nil {
+		return Result{}, err
+	}
+	localContent, err := st.Read(entry.LocalPath)
+	if err != nil {
+		return Result{}, err
+	}
+	if status.Stale {
+		baseline, err := artifact.BaselineContent(st, entry)
+		if err != nil {
+			return Result{}, err
+		}
+		return Result{
+			Status:       StatusMergeRequired,
+			Entry:        entry,
+			LocalPath:    entry.LocalPath,
+			StatusDetail: status,
+			MergeRequest: &MergeRequest{
+				Kind:            entry.Kind,
+				Name:            entry.Name,
+				LocalPath:       entry.LocalPath,
+				NotionURL:       entry.NotionURL,
+				PageID:          entry.PageID,
+				ExternalID:      entry.ExternalID,
+				BaselineVersion: entry.RemoteVersion,
+				RemoteVersion:   req.RemoteVersion,
+				BaselineContent: string(baseline),
+				LocalContent:    string(localContent),
+				RemoteContent:   req.RemoteContent,
+				RequiredAction:  "Merge baseline, local, and remote content; then run resolve-merge before retrying prepare-push.",
+			},
+			Next: "Run resolve-merge with resolved content before updating Notion.",
+		}, nil
+	}
+	if !status.Dirty {
+		return Result{
+			Status:       StatusClean,
+			Entry:        entry,
+			LocalPath:    entry.LocalPath,
+			StatusDetail: status,
+			Next:         "No Notion update is required.",
+		}, nil
+	}
+	return Result{
+		Status:       StatusReady,
+		Entry:        entry,
+		LocalPath:    entry.LocalPath,
+		LocalContent: string(localContent),
+		StatusDetail: status,
+		Changed:      true,
+		Next:         "Update the Notion page with local_content, then run commit-push with the returned remote metadata.",
+	}, nil
+}
+
+// CommitPush records a successful Notion MCP update as the new clean baseline.
+func CommitPush(st store.Store, cfg config.Config, req CommitRequest) (Result, error) {
+	if err := validateRemote(req.Remote); err != nil {
+		return Result{}, err
+	}
+	entry, err := lookupEntry(st, cfg, req.IdentityRequest)
+	if err != nil {
+		return Result{}, err
+	}
+	content, err := st.Read(entry.LocalPath)
+	if err != nil {
+		return Result{}, err
+	}
+	entry, err = artifact.UpdateBaseline(st, cfg, entry, content, req.Remote)
+	if err != nil {
+		return Result{}, err
+	}
+	return Result{
+		Status:    StatusCommitted,
+		Entry:     entry,
+		LocalPath: entry.LocalPath,
+		Changed:   true,
+		Next:      "The cache is clean against the returned Notion version.",
+	}, nil
+}
+
+// ResolveMerge records resolved content and advances the baseline to the remote version.
+func ResolveMerge(st store.Store, cfg config.Config, req MergeRequestInput) (Result, error) {
+	if err := validateRemote(req.Remote); err != nil {
+		return Result{}, err
+	}
+	entry, err := lookupEntry(st, cfg, req.IdentityRequest)
+	if err != nil {
+		return Result{}, err
+	}
+	if req.ResolvedContent == "" {
+		return Result{}, fmt.Errorf("resolved_content is required")
+	}
+	if err := st.Write(entry.LocalPath, []byte(req.ResolvedContent)); err != nil {
+		return Result{}, err
+	}
+	entry, err = artifact.UpdateBaseline(st, cfg, entry, []byte(req.RemoteContent), req.Remote)
+	if err != nil {
+		return Result{}, err
+	}
+	status, err := artifact.EntryStatus(st, entry, req.Remote.RemoteVersion)
+	if err != nil {
+		return Result{}, err
+	}
+	return Result{
+		Status:       StatusResolved,
+		Entry:        entry,
+		LocalPath:    entry.LocalPath,
+		StatusDetail: status,
+		Changed:      true,
+		Next:         "Retry prepare-push with the same remote version before updating Notion.",
+	}, nil
+}
+
+func lookupEntry(st store.Store, cfg config.Config, req IdentityRequest) (artifact.Entry, error) {
+	manifest, err := artifact.LoadManifest(st, cfg)
+	if err != nil {
+		return artifact.Entry{}, err
+	}
+	if req.Kind != "" && req.Name != "" {
+		entry, ok := manifest.Entries[artifact.Key(req.Kind, req.Name)]
+		if ok {
+			return entry, nil
+		}
+	}
+	entry, ok := manifest.Find(artifact.Identity{
+		Kind:       req.Kind,
+		NotionURL:  req.NotionURL,
+		PageID:     req.PageID,
+		ExternalID: req.ExternalID,
+	})
+	if !ok {
+		return artifact.Entry{}, fmt.Errorf("cached artifact not found")
+	}
+	return entry, nil
+}
+
+func validateRemote(remote artifact.RemoteMetadata) error {
+	return artifact.ValidateRemoteMetadata(remote)
+}

--- a/internal/artifact/sync/sync_test.go
+++ b/internal/artifact/sync/sync_test.go
@@ -1,0 +1,181 @@
+package sync
+
+import (
+	"testing"
+
+	"github.com/jumppad-labs/spektacular/internal/artifact"
+	"github.com/jumppad-labs/spektacular/internal/config"
+	"github.com/jumppad-labs/spektacular/internal/store"
+	"github.com/stretchr/testify/require"
+)
+
+func testConfig() config.Config {
+	cfg := config.NewDefault()
+	cfg.Spec.IDMethod = config.SpecIDMethodExternal
+	cfg.Artifacts.Backend = config.ArtifactBackendNotion
+	cfg.Artifacts.Notion.SpecsDataSource = "collection://specs"
+	cfg.Artifacts.Notion.PlansDataSource = "collection://plans"
+	return cfg
+}
+
+func testRemote(version string) artifact.RemoteMetadata {
+	return artifact.RemoteMetadata{
+		NotionURL:     "https://notion.so/spec",
+		PageID:        "page-123",
+		DataSourceURL: "collection://specs",
+		ExternalID:    "SPEC-1",
+		RemoteVersion: version,
+		Title:         "Spec 1",
+	}
+}
+
+func TestPullWritesCacheAndManifest(t *testing.T) {
+	cfg := testConfig()
+	st := store.NewFileStore(t.TempDir())
+
+	result, err := Pull(st, cfg, PullRequest{
+		Kind:    artifact.KindSpec,
+		Name:    "spec-1",
+		Content: "baseline",
+		Remote:  testRemote("v1"),
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, StatusPulled, result.Status)
+	require.Equal(t, "cache/notion/specs/spec-1.md", result.Entry.LocalPath)
+	require.Equal(t, "cache/notion/.baseline/specs/spec-1.md", result.Entry.BaselinePath)
+	require.Equal(t, artifact.Checksum([]byte("baseline")), result.Entry.Checksum)
+
+	manifest, err := artifact.LoadManifest(st, cfg)
+	require.NoError(t, err)
+	require.Equal(t, result.Entry, manifest.Entries[artifact.Key(artifact.KindSpec, "spec-1")])
+}
+
+func TestPreparePushReturnsMergeRequestWhenRemoteChanged(t *testing.T) {
+	cfg := testConfig()
+	st := store.NewFileStore(t.TempDir())
+	pulled, err := Pull(st, cfg, PullRequest{
+		Kind:    artifact.KindSpec,
+		Name:    "spec-1",
+		Content: "baseline",
+		Remote:  testRemote("v1"),
+	})
+	require.NoError(t, err)
+	require.NoError(t, st.Write(pulled.Entry.LocalPath, []byte("local edit")))
+
+	result, err := PreparePush(st, cfg, PushRequest{
+		IdentityRequest: IdentityRequest{Kind: artifact.KindSpec, Name: "spec-1"},
+		RemoteVersion:   "v2",
+		RemoteContent:   "remote edit",
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, StatusMergeRequired, result.Status)
+	require.NotNil(t, result.MergeRequest)
+	require.Equal(t, "baseline", result.MergeRequest.BaselineContent)
+	require.Equal(t, "local edit", result.MergeRequest.LocalContent)
+	require.Equal(t, "remote edit", result.MergeRequest.RemoteContent)
+	require.Equal(t, "v1", result.MergeRequest.BaselineVersion)
+	require.Equal(t, "v2", result.MergeRequest.RemoteVersion)
+	require.Contains(t, result.MergeRequest.RequiredAction, "resolve-merge")
+}
+
+func TestResolveMergeAllowsRetryingPreparePush(t *testing.T) {
+	cfg := testConfig()
+	st := store.NewFileStore(t.TempDir())
+	pulled, err := Pull(st, cfg, PullRequest{
+		Kind:    artifact.KindSpec,
+		Name:    "spec-1",
+		Content: "baseline",
+		Remote:  testRemote("v1"),
+	})
+	require.NoError(t, err)
+	require.NoError(t, st.Write(pulled.Entry.LocalPath, []byte("local edit")))
+
+	resolved, err := ResolveMerge(st, cfg, MergeRequestInput{
+		IdentityRequest: IdentityRequest{Kind: artifact.KindSpec, Name: "spec-1"},
+		Remote:          testRemote("v2"),
+		RemoteContent:   "remote edit",
+		ResolvedContent: "merged content",
+	})
+	require.NoError(t, err)
+	require.Equal(t, StatusResolved, resolved.Status)
+	require.True(t, resolved.StatusDetail.Dirty)
+	require.False(t, resolved.StatusDetail.Stale)
+
+	prepared, err := PreparePush(st, cfg, PushRequest{
+		IdentityRequest: IdentityRequest{Kind: artifact.KindSpec, Name: "spec-1"},
+		RemoteVersion:   "v2",
+		RemoteContent:   "remote edit",
+	})
+	require.NoError(t, err)
+	require.Equal(t, StatusReady, prepared.Status)
+	require.Equal(t, "merged content", prepared.LocalContent)
+}
+
+func TestCommitPushUpdatesManifestToNewRemoteVersion(t *testing.T) {
+	cfg := testConfig()
+	st := store.NewFileStore(t.TempDir())
+	pulled, err := Pull(st, cfg, PullRequest{
+		Kind:    artifact.KindSpec,
+		Name:    "spec-1",
+		Content: "baseline",
+		Remote:  testRemote("v1"),
+	})
+	require.NoError(t, err)
+	require.NoError(t, st.Write(pulled.Entry.LocalPath, []byte("local edit")))
+
+	committed, err := CommitPush(st, cfg, CommitRequest{
+		IdentityRequest: IdentityRequest{Kind: artifact.KindSpec, Name: "spec-1"},
+		Remote:          testRemote("v2"),
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, StatusCommitted, committed.Status)
+	require.Equal(t, "v2", committed.Entry.RemoteVersion)
+	require.Equal(t, artifact.Checksum([]byte("local edit")), committed.Entry.Checksum)
+	status, err := artifact.EntryStatus(st, committed.Entry, "v2")
+	require.NoError(t, err)
+	require.False(t, status.Dirty)
+	require.False(t, status.Stale)
+}
+
+func TestLookupByNotionURLPageIDAndExternalID(t *testing.T) {
+	cfg := testConfig()
+	st := store.NewFileStore(t.TempDir())
+	_, err := Pull(st, cfg, PullRequest{
+		Kind:    artifact.KindSpec,
+		Name:    "spec-1",
+		Content: "baseline",
+		Remote:  testRemote("v1"),
+	})
+	require.NoError(t, err)
+
+	for _, req := range []IdentityRequest{
+		{NotionURL: "https://notion.so/spec"},
+		{PageID: "page-123"},
+		{Kind: artifact.KindSpec, ExternalID: "SPEC-1"},
+	} {
+		result, err := Status(st, cfg, PushRequest{IdentityRequest: req})
+		require.NoError(t, err)
+		require.Equal(t, "spec-1", result.Entry.Name)
+	}
+}
+
+func TestMissingManifestEntryAndMalformedRemoteReturnErrors(t *testing.T) {
+	cfg := testConfig()
+	st := store.NewFileStore(t.TempDir())
+
+	_, err := PreparePush(st, cfg, PushRequest{IdentityRequest: IdentityRequest{Kind: artifact.KindSpec, Name: "missing"}})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not found")
+
+	_, err = Pull(st, cfg, PullRequest{
+		Kind:    artifact.KindSpec,
+		Name:    "spec-1",
+		Content: "baseline",
+		Remote:  artifact.RemoteMetadata{PageID: "page-123"},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "remote.notion_url")
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,6 +14,13 @@ const (
 	SpecIDMethodTimestamp = "timestamp"
 	SpecIDMethodCounter   = "counter"
 	SpecIDMethodExternal  = "external"
+
+	ArtifactBackendLocal  = "local"
+	ArtifactBackendNotion = "notion"
+
+	DefaultNotionCacheDir     = "cache/notion"
+	DefaultSpecIDPropertyName = "Spec ID"
+	DefaultPlanIDPropertyName = "Plan ID"
 )
 
 // DebugConfig holds debug logging configuration.
@@ -27,12 +34,29 @@ type SpecConfig struct {
 	Counter  int    `yaml:"counter"`
 }
 
+// ArtifactsConfig holds configuration for Spektacular artifact storage.
+type ArtifactsConfig struct {
+	Backend  string       `yaml:"backend"`
+	CacheDir string       `yaml:"cache_dir"`
+	Notion   NotionConfig `yaml:"notion"`
+}
+
+// NotionConfig holds configuration for linked Notion artifact databases.
+type NotionConfig struct {
+	BasePageURL     string `yaml:"base_page_url"`
+	SpecsDataSource string `yaml:"specs_data_source"`
+	PlansDataSource string `yaml:"plans_data_source"`
+	SpecIDProperty  string `yaml:"spec_id_property"`
+	PlanIDProperty  string `yaml:"plan_id_property"`
+}
+
 // Config is the top-level Spektacular configuration.
 type Config struct {
-	Command string      `yaml:"command"`
-	Agent   string      `yaml:"agent"`
-	Debug   DebugConfig `yaml:"debug"`
-	Spec    SpecConfig  `yaml:"spec"`
+	Command   string          `yaml:"command"`
+	Agent     string          `yaml:"agent"`
+	Debug     DebugConfig     `yaml:"debug"`
+	Spec      SpecConfig      `yaml:"spec"`
+	Artifacts ArtifactsConfig `yaml:"artifacts"`
 }
 
 // NewDefault returns a Config populated with default values.
@@ -45,6 +69,14 @@ func NewDefault() Config {
 		Spec: SpecConfig{
 			IDMethod: SpecIDMethodTimestamp,
 			Counter:  0,
+		},
+		Artifacts: ArtifactsConfig{
+			Backend:  ArtifactBackendLocal,
+			CacheDir: DefaultNotionCacheDir,
+			Notion: NotionConfig{
+				SpecIDProperty: DefaultSpecIDPropertyName,
+				PlanIDProperty: DefaultPlanIDPropertyName,
+			},
 		},
 	}
 }
@@ -73,6 +105,9 @@ func (c Config) Validate() error {
 	if err := c.Spec.Validate(); err != nil {
 		return err
 	}
+	if err := c.Artifacts.Validate(c.Spec); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -84,6 +119,45 @@ func (c SpecConfig) Validate() error {
 	default:
 		return fmt.Errorf("spec.id_method must be one of %q, %q, or %q", SpecIDMethodTimestamp, SpecIDMethodCounter, SpecIDMethodExternal)
 	}
+}
+
+// Validate checks whether the artifact config contains supported values.
+func (c ArtifactsConfig) Validate(spec SpecConfig) error {
+	backend := c.Backend
+	if backend == "" {
+		backend = ArtifactBackendLocal
+	}
+
+	switch backend {
+	case ArtifactBackendLocal:
+		return nil
+	case ArtifactBackendNotion:
+		return c.validateNotion(spec)
+	default:
+		return fmt.Errorf("artifacts.backend must be one of %q or %q", ArtifactBackendLocal, ArtifactBackendNotion)
+	}
+}
+
+func (c ArtifactsConfig) validateNotion(spec SpecConfig) error {
+	if spec.IDMethod != SpecIDMethodExternal {
+		return fmt.Errorf("spec.id_method must be %q when artifacts.backend is %q", SpecIDMethodExternal, ArtifactBackendNotion)
+	}
+	if c.CacheDir == "" {
+		return fmt.Errorf("artifacts.cache_dir is required when artifacts.backend is %q", ArtifactBackendNotion)
+	}
+	if c.Notion.SpecsDataSource == "" {
+		return fmt.Errorf("artifacts.notion.specs_data_source is required when artifacts.backend is %q", ArtifactBackendNotion)
+	}
+	if c.Notion.PlansDataSource == "" {
+		return fmt.Errorf("artifacts.notion.plans_data_source is required when artifacts.backend is %q", ArtifactBackendNotion)
+	}
+	if c.Notion.SpecIDProperty == "" {
+		return fmt.Errorf("artifacts.notion.spec_id_property is required when artifacts.backend is %q", ArtifactBackendNotion)
+	}
+	if c.Notion.PlanIDProperty == "" {
+		return fmt.Errorf("artifacts.notion.plan_id_property is required when artifacts.backend is %q", ArtifactBackendNotion)
+	}
+	return nil
 }
 
 // ToYAMLFile writes the Config to a YAML file.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,9 +10,21 @@ import (
 
 var envVarPattern = regexp.MustCompile(`\$\{([^}]+)\}`)
 
+const (
+	SpecIDMethodTimestamp = "timestamp"
+	SpecIDMethodCounter   = "counter"
+	SpecIDMethodExternal  = "external"
+)
+
 // DebugConfig holds debug logging configuration.
 type DebugConfig struct {
 	Enabled bool `yaml:"enabled"`
+}
+
+// SpecConfig holds configuration for specification creation.
+type SpecConfig struct {
+	IDMethod string `yaml:"id_method"`
+	Counter  int    `yaml:"counter"`
 }
 
 // Config is the top-level Spektacular configuration.
@@ -20,6 +32,7 @@ type Config struct {
 	Command string      `yaml:"command"`
 	Agent   string      `yaml:"agent"`
 	Debug   DebugConfig `yaml:"debug"`
+	Spec    SpecConfig  `yaml:"spec"`
 }
 
 // NewDefault returns a Config populated with default values.
@@ -28,6 +41,10 @@ func NewDefault() Config {
 		Command: "spektacular",
 		Debug: DebugConfig{
 			Enabled: false,
+		},
+		Spec: SpecConfig{
+			IDMethod: SpecIDMethodTimestamp,
+			Counter:  0,
 		},
 	}
 }
@@ -45,7 +62,28 @@ func FromYAMLFile(path string) (Config, error) {
 	if err := yaml.Unmarshal([]byte(expanded), &cfg); err != nil {
 		return Config{}, fmt.Errorf("parsing config file %s: %w", path, err)
 	}
+	if err := cfg.Validate(); err != nil {
+		return Config{}, fmt.Errorf("validating config file %s: %w", path, err)
+	}
 	return cfg, nil
+}
+
+// Validate checks whether the config contains supported values.
+func (c Config) Validate() error {
+	if err := c.Spec.Validate(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Validate checks whether the spec config contains supported values.
+func (c SpecConfig) Validate() error {
+	switch c.IDMethod {
+	case "", SpecIDMethodTimestamp, SpecIDMethodCounter, SpecIDMethodExternal:
+		return nil
+	default:
+		return fmt.Errorf("spec.id_method must be one of %q, %q, or %q", SpecIDMethodTimestamp, SpecIDMethodCounter, SpecIDMethodExternal)
+	}
 }
 
 // ToYAMLFile writes the Config to a YAML file.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -15,6 +15,10 @@ func TestNewDefault_HasExpectedDefaults(t *testing.T) {
 	require.False(t, cfg.Debug.Enabled)
 	require.Equal(t, "timestamp", cfg.Spec.IDMethod)
 	require.Equal(t, 0, cfg.Spec.Counter)
+	require.Equal(t, "local", cfg.Artifacts.Backend)
+	require.Equal(t, "cache/notion", cfg.Artifacts.CacheDir)
+	require.Equal(t, "Spec ID", cfg.Artifacts.Notion.SpecIDProperty)
+	require.Equal(t, "Plan ID", cfg.Artifacts.Notion.PlanIDProperty)
 }
 
 func TestFromYAMLFile_LoadsAndExpandsEnvVars(t *testing.T) {
@@ -31,6 +35,8 @@ func TestFromYAMLFile_LoadsAndExpandsEnvVars(t *testing.T) {
 	require.Equal(t, "go run .", cfg.Command)
 	require.Equal(t, "timestamp", cfg.Spec.IDMethod)
 	require.Equal(t, 0, cfg.Spec.Counter)
+	require.Equal(t, "local", cfg.Artifacts.Backend)
+	require.Equal(t, "cache/notion", cfg.Artifacts.CacheDir)
 }
 
 func TestFromYAMLFile_MissingSpecConfigUsesDefaults(t *testing.T) {
@@ -60,6 +66,103 @@ func TestFromYAMLFile_UnknownSpecIDMethodReturnsError(t *testing.T) {
 	require.Contains(t, err.Error(), "spec.id_method")
 }
 
+func TestFromYAMLFile_UnknownArtifactBackendReturnsError(t *testing.T) {
+	yaml := `artifacts:
+  backend: unsupported`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	err := os.WriteFile(path, []byte(yaml), 0644)
+	require.NoError(t, err)
+
+	_, err = FromYAMLFile(path)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "artifacts.backend")
+}
+
+func TestFromYAMLFile_NotionBackendRequiresExternalSpecIDs(t *testing.T) {
+	yaml := `artifacts:
+  backend: notion
+  cache_dir: cache/notion
+  notion:
+    specs_data_source: collection://specs
+    plans_data_source: collection://plans`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	err := os.WriteFile(path, []byte(yaml), 0644)
+	require.NoError(t, err)
+
+	_, err = FromYAMLFile(path)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "spec.id_method")
+	require.Contains(t, err.Error(), "external")
+}
+
+func TestFromYAMLFile_NotionBackendRequiresLinkedLocations(t *testing.T) {
+	yaml := `spec:
+  id_method: external
+artifacts:
+  backend: notion
+  cache_dir: cache/notion
+  notion:
+    plans_data_source: collection://plans`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	err := os.WriteFile(path, []byte(yaml), 0644)
+	require.NoError(t, err)
+
+	_, err = FromYAMLFile(path)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "artifacts.notion.specs_data_source")
+}
+
+func TestFromYAMLFile_NotionBackendRequiresIdentifierProperties(t *testing.T) {
+	yaml := `spec:
+  id_method: external
+artifacts:
+  backend: notion
+  cache_dir: cache/notion
+  notion:
+    specs_data_source: collection://specs
+    plans_data_source: collection://plans
+    spec_id_property: ""
+    plan_id_property: "Plan ID"`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	err := os.WriteFile(path, []byte(yaml), 0644)
+	require.NoError(t, err)
+
+	_, err = FromYAMLFile(path)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "artifacts.notion.spec_id_property")
+}
+
+func TestFromYAMLFile_NotionBackendLoadsWithRequiredFields(t *testing.T) {
+	yaml := `spec:
+  id_method: external
+artifacts:
+  backend: notion
+  cache_dir: cache/notion
+  notion:
+    base_page_url: https://notion.example/base
+    specs_data_source: collection://specs
+    plans_data_source: collection://plans`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	err := os.WriteFile(path, []byte(yaml), 0644)
+	require.NoError(t, err)
+
+	cfg, err := FromYAMLFile(path)
+	require.NoError(t, err)
+	require.Equal(t, "external", cfg.Spec.IDMethod)
+	require.Equal(t, "notion", cfg.Artifacts.Backend)
+	require.Equal(t, "cache/notion", cfg.Artifacts.CacheDir)
+	require.Equal(t, "https://notion.example/base", cfg.Artifacts.Notion.BasePageURL)
+	require.Equal(t, "collection://specs", cfg.Artifacts.Notion.SpecsDataSource)
+	require.Equal(t, "collection://plans", cfg.Artifacts.Notion.PlansDataSource)
+	require.Equal(t, "Spec ID", cfg.Artifacts.Notion.SpecIDProperty)
+	require.Equal(t, "Plan ID", cfg.Artifacts.Notion.PlanIDProperty)
+}
+
 func TestFromYAMLFile_MissingFile_ReturnsError(t *testing.T) {
 	_, err := FromYAMLFile("/nonexistent/path/config.yaml")
 	require.Error(t, err)
@@ -79,4 +182,8 @@ func TestToYAMLFile_RoundTrip(t *testing.T) {
 	require.Equal(t, cfg.Debug.Enabled, loaded.Debug.Enabled)
 	require.Equal(t, cfg.Spec.IDMethod, loaded.Spec.IDMethod)
 	require.Equal(t, cfg.Spec.Counter, loaded.Spec.Counter)
+	require.Equal(t, cfg.Artifacts.Backend, loaded.Artifacts.Backend)
+	require.Equal(t, cfg.Artifacts.CacheDir, loaded.Artifacts.CacheDir)
+	require.Equal(t, cfg.Artifacts.Notion.SpecIDProperty, loaded.Artifacts.Notion.SpecIDProperty)
+	require.Equal(t, cfg.Artifacts.Notion.PlanIDProperty, loaded.Artifacts.Notion.PlanIDProperty)
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -13,6 +13,8 @@ func TestNewDefault_HasExpectedDefaults(t *testing.T) {
 
 	require.Equal(t, "spektacular", cfg.Command)
 	require.False(t, cfg.Debug.Enabled)
+	require.Equal(t, "timestamp", cfg.Spec.IDMethod)
+	require.Equal(t, 0, cfg.Spec.Counter)
 }
 
 func TestFromYAMLFile_LoadsAndExpandsEnvVars(t *testing.T) {
@@ -27,6 +29,35 @@ func TestFromYAMLFile_LoadsAndExpandsEnvVars(t *testing.T) {
 	cfg, err := FromYAMLFile(path)
 	require.NoError(t, err)
 	require.Equal(t, "go run .", cfg.Command)
+	require.Equal(t, "timestamp", cfg.Spec.IDMethod)
+	require.Equal(t, 0, cfg.Spec.Counter)
+}
+
+func TestFromYAMLFile_MissingSpecConfigUsesDefaults(t *testing.T) {
+	yaml := `command: "go run ."`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	err := os.WriteFile(path, []byte(yaml), 0644)
+	require.NoError(t, err)
+
+	cfg, err := FromYAMLFile(path)
+	require.NoError(t, err)
+	require.Equal(t, "go run .", cfg.Command)
+	require.Equal(t, "timestamp", cfg.Spec.IDMethod)
+	require.Equal(t, 0, cfg.Spec.Counter)
+}
+
+func TestFromYAMLFile_UnknownSpecIDMethodReturnsError(t *testing.T) {
+	yaml := `spec:
+  id_method: unsupported`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	err := os.WriteFile(path, []byte(yaml), 0644)
+	require.NoError(t, err)
+
+	_, err = FromYAMLFile(path)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "spec.id_method")
 }
 
 func TestFromYAMLFile_MissingFile_ReturnsError(t *testing.T) {
@@ -46,4 +77,6 @@ func TestToYAMLFile_RoundTrip(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, cfg.Command, loaded.Command)
 	require.Equal(t, cfg.Debug.Enabled, loaded.Debug.Enabled)
+	require.Equal(t, cfg.Spec.IDMethod, loaded.Spec.IDMethod)
+	require.Equal(t, cfg.Spec.Counter, loaded.Spec.Counter)
 }

--- a/internal/notion/schema/parse.go
+++ b/internal/notion/schema/parse.go
@@ -1,0 +1,85 @@
+package schema
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// ParseDataSource parses either a direct data-source-state JSON object or the
+// JSON/text wrapper returned by the Notion MCP fetch tool.
+func ParseDataSource(raw []byte) (DataSource, error) {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 {
+		return DataSource{}, fmt.Errorf("empty data source snapshot")
+	}
+
+	if ds, ok := parseDirect(raw); ok {
+		return ds, nil
+	}
+
+	var textWrapper struct {
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(raw, &textWrapper); err == nil && textWrapper.Text != "" {
+		return ParseDataSource([]byte(textWrapper.Text))
+	}
+
+	var mcpItems []struct {
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(raw, &mcpItems); err == nil {
+		for _, item := range mcpItems {
+			if item.Text == "" {
+				continue
+			}
+			ds, err := ParseDataSource([]byte(item.Text))
+			if err == nil {
+				return ds, nil
+			}
+		}
+	}
+
+	if state := extractBetween(string(raw), "<data-source-state>", "</data-source-state>"); state != "" {
+		if ds, ok := parseDirect([]byte(state)); ok {
+			return ds, nil
+		}
+	}
+
+	return DataSource{}, fmt.Errorf("unsupported Notion data source snapshot")
+}
+
+func parseDirect(raw []byte) (DataSource, bool) {
+	var ds DataSource
+	if err := json.Unmarshal(raw, &ds); err != nil {
+		return DataSource{}, false
+	}
+	if ds.URL == "" && len(ds.Schema) == 0 {
+		return DataSource{}, false
+	}
+	normalizePropertyNames(ds.Schema)
+	return ds, true
+}
+
+func normalizePropertyNames(props map[string]Property) {
+	for name, prop := range props {
+		if prop.Name == "" {
+			prop.Name = name
+			props[name] = prop
+		}
+	}
+}
+
+func extractBetween(s, start, end string) string {
+	startIdx := strings.Index(s, start)
+	if startIdx == -1 {
+		return ""
+	}
+	startIdx += len(start)
+	endIdx := strings.Index(s[startIdx:], end)
+	if endIdx == -1 {
+		return ""
+	}
+	return s[startIdx : startIdx+endIdx]
+}

--- a/internal/notion/schema/schema.go
+++ b/internal/notion/schema/schema.go
@@ -1,0 +1,344 @@
+package schema
+
+import (
+	"fmt"
+	"sort"
+)
+
+const (
+	SeverityBlocking = "blocking"
+	SeverityFixable  = "fixable"
+
+	DataSourceSpecs = "specs"
+	DataSourcePlans = "plans"
+
+	TypeAutoIncrementID = "auto_increment_id"
+	TypeCreatedTime     = "created_time"
+	TypeLastEditedTime  = "last_edited_time"
+	TypeMultiSelect     = "multi_select"
+	TypePerson          = "person"
+	TypeRelation        = "relation"
+	TypeSelect          = "select"
+	TypeTitle           = "title"
+	TypeURL             = "url"
+)
+
+// DataSource is the small schema snapshot Spektacular needs from Notion MCP.
+type DataSource struct {
+	Name   string              `json:"name,omitempty"`
+	URL    string              `json:"url"`
+	Schema map[string]Property `json:"schema"`
+}
+
+// Property describes a Notion data source property in MCP fetch output.
+type Property struct {
+	Name          string   `json:"name"`
+	Type          string   `json:"type"`
+	DataSourceURL string   `json:"dataSourceUrl,omitempty"`
+	Options       []Option `json:"options,omitempty"`
+}
+
+// Option describes a select or multi-select option.
+type Option struct {
+	Name  string `json:"name"`
+	Color string `json:"color,omitempty"`
+}
+
+// ValidationOptions controls linked database validation.
+type ValidationOptions struct {
+	SpecsDataSource string
+	PlansDataSource string
+	SpecIDProperty  string
+	PlanIDProperty  string
+}
+
+// Issue is a validation finding for a linked Notion data source.
+type Issue struct {
+	ID              string `json:"id"`
+	Severity        string `json:"severity"`
+	DataSource      string `json:"data_source"`
+	Property        string `json:"property,omitempty"`
+	ExpectedType    string `json:"expected_type,omitempty"`
+	ActualType      string `json:"actual_type,omitempty"`
+	Message         string `json:"message"`
+	Repairable      bool   `json:"repairable"`
+	RepairStatement string `json:"repair_statement,omitempty"`
+}
+
+// Repair is a safe additive schema change the agent can apply through Notion MCP.
+type Repair struct {
+	ID               string `json:"id"`
+	DataSource       string `json:"data_source"`
+	DataSourceURL    string `json:"data_source_url"`
+	Property         string `json:"property"`
+	Type             string `json:"type"`
+	Statement        string `json:"statement"`
+	RequiresApproval bool   `json:"requires_approval"`
+}
+
+// Report is the full schema validation result.
+type Report struct {
+	Valid          bool     `json:"valid"`
+	BlockingIssues []Issue  `json:"blocking_issues"`
+	FixableIssues  []Issue  `json:"fixable_issues"`
+	Repairs        []Repair `json:"repairs"`
+}
+
+type requirement struct {
+	dataSource string
+	property   string
+	typ        string
+	target     string
+	blocking   bool
+	statement  string
+}
+
+// ValidatePair validates Specs and Plans data source snapshots together.
+func ValidatePair(specs, plans DataSource, opts ValidationOptions) Report {
+	opts = applyDefaults(opts)
+
+	reqs := []requirement{
+		{dataSource: DataSourceSpecs, property: "Name", typ: TypeTitle, blocking: true},
+		{dataSource: DataSourceSpecs, property: opts.SpecIDProperty, typ: TypeAutoIncrementID, blocking: true},
+		{dataSource: DataSourceSpecs, property: "Created", typ: TypeCreatedTime, statement: `ADD COLUMN "Created" CREATED_TIME`},
+		{dataSource: DataSourceSpecs, property: "Last Edited", typ: TypeLastEditedTime, statement: `ADD COLUMN "Last Edited" LAST_EDITED_TIME`},
+		{dataSource: DataSourceSpecs, property: "Status", typ: TypeSelect, statement: `ADD COLUMN "Status" SELECT('Drafting':gray, 'In Review':yellow, 'Approved':green, 'Building':blue, 'Shipped':purple, 'Superseded':red)`},
+		{dataSource: DataSourceSpecs, property: "Approval", typ: TypeSelect, statement: `ADD COLUMN "Approval" SELECT('Draft':gray, 'Approved':green)`},
+		{dataSource: DataSourceSpecs, property: "Tags", typ: TypeMultiSelect, statement: `ADD COLUMN "Tags" MULTI_SELECT('security':red, 'compliance':orange, 'platform':blue, 'infra':purple, 'growth':green, 'developer-experience':yellow, 'ai':pink)`},
+		{dataSource: DataSourceSpecs, property: "Author", typ: TypePerson, statement: `ADD COLUMN "Author" PEOPLE`},
+		{dataSource: DataSourceSpecs, property: "Reviewers", typ: TypePerson, statement: `ADD COLUMN "Reviewers" PEOPLE`},
+		{dataSource: DataSourceSpecs, property: "Plan", typ: TypeRelation, target: opts.PlansDataSource, statement: fmt.Sprintf(`ADD COLUMN "Plan" RELATION('%s')`, opts.PlansDataSource)},
+
+		{dataSource: DataSourcePlans, property: "Name", typ: TypeTitle, blocking: true},
+		{dataSource: DataSourcePlans, property: opts.PlanIDProperty, typ: TypeAutoIncrementID, blocking: true},
+		{dataSource: DataSourcePlans, property: "Created", typ: TypeCreatedTime, statement: `ADD COLUMN "Created" CREATED_TIME`},
+		{dataSource: DataSourcePlans, property: "Last Edited", typ: TypeLastEditedTime, statement: `ADD COLUMN "Last Edited" LAST_EDITED_TIME`},
+		{dataSource: DataSourcePlans, property: "Status", typ: TypeSelect, statement: `ADD COLUMN "Status" SELECT('Drafting':gray, 'In Review':yellow, 'Approved':green, 'Building':blue, 'Shipped':purple, 'Superseded':red)`},
+		{dataSource: DataSourcePlans, property: "Approval", typ: TypeSelect, statement: `ADD COLUMN "Approval" SELECT('Draft':gray, 'Approved':green)`},
+		{dataSource: DataSourcePlans, property: "Tags", typ: TypeMultiSelect, statement: `ADD COLUMN "Tags" MULTI_SELECT('security':red, 'compliance':orange, 'platform':blue, 'infra':purple, 'growth':green, 'developer-experience':yellow, 'ai':pink)`},
+		{dataSource: DataSourcePlans, property: "Author", typ: TypePerson, statement: `ADD COLUMN "Author" PEOPLE`},
+		{dataSource: DataSourcePlans, property: "Reviewers", typ: TypePerson, statement: `ADD COLUMN "Reviewers" PEOPLE`},
+		{dataSource: DataSourcePlans, property: "Spec", typ: TypeRelation, target: opts.SpecsDataSource, statement: fmt.Sprintf(`ADD COLUMN "Spec" RELATION('%s')`, opts.SpecsDataSource)},
+		{dataSource: DataSourcePlans, property: "Linear Issues", typ: TypeURL, statement: `ADD COLUMN "Linear Issues" URL`},
+	}
+
+	var report Report
+	report.BlockingIssues = append(report.BlockingIssues, validateDataSourceIdentity(DataSourceSpecs, specs, opts.SpecsDataSource)...)
+	report.BlockingIssues = append(report.BlockingIssues, validateDataSourceIdentity(DataSourcePlans, plans, opts.PlansDataSource)...)
+
+	for _, req := range reqs {
+		ds := specs
+		if req.dataSource == DataSourcePlans {
+			ds = plans
+		}
+		issue, repair, ok := validateRequirement(ds, req)
+		if !ok {
+			continue
+		}
+		if issue.Severity == SeverityBlocking {
+			report.BlockingIssues = append(report.BlockingIssues, issue)
+			continue
+		}
+		report.FixableIssues = append(report.FixableIssues, issue)
+		report.Repairs = append(report.Repairs, repair)
+	}
+
+	sortIssues(report.BlockingIssues)
+	sortIssues(report.FixableIssues)
+	sortRepairs(report.Repairs)
+	report.Valid = len(report.BlockingIssues) == 0 && len(report.FixableIssues) == 0
+	return report
+}
+
+// ApplyApprovedRepairs applies approved safe additive repairs to local snapshots.
+func ApplyApprovedRepairs(specs, plans DataSource, repairs []Repair, approvedIDs []string) (DataSource, DataSource, []Repair) {
+	specs = cloneDataSource(specs)
+	plans = cloneDataSource(plans)
+
+	approved := make(map[string]bool, len(approvedIDs))
+	for _, id := range approvedIDs {
+		approved[id] = true
+	}
+
+	var applied []Repair
+	for _, repair := range repairs {
+		if !approved[repair.ID] {
+			continue
+		}
+		target := &specs
+		if repair.DataSource == DataSourcePlans {
+			target = &plans
+		}
+		if target.Schema == nil {
+			target.Schema = map[string]Property{}
+		}
+		if _, exists := target.Schema[repair.Property]; exists {
+			continue
+		}
+		prop := Property{Name: repair.Property, Type: repair.Type}
+		if repair.Type == TypeRelation {
+			if repair.DataSource == DataSourceSpecs {
+				prop.DataSourceURL = plans.URL
+			} else {
+				prop.DataSourceURL = specs.URL
+			}
+		}
+		target.Schema[repair.Property] = prop
+		applied = append(applied, repair)
+	}
+
+	sortRepairs(applied)
+	return specs, plans, applied
+}
+
+func applyDefaults(opts ValidationOptions) ValidationOptions {
+	if opts.SpecIDProperty == "" {
+		opts.SpecIDProperty = "Spec ID"
+	}
+	if opts.PlanIDProperty == "" {
+		opts.PlanIDProperty = "Plan ID"
+	}
+	return opts
+}
+
+func validateDataSourceIdentity(kind string, ds DataSource, expectedURL string) []Issue {
+	var issues []Issue
+	if ds.URL == "" {
+		issues = append(issues, Issue{
+			ID:         issueID(kind, "data_source", "missing"),
+			Severity:   SeverityBlocking,
+			DataSource: kind,
+			Message:    fmt.Sprintf("%s data source snapshot is missing url", kind),
+		})
+	} else if expectedURL != "" && ds.URL != expectedURL {
+		issues = append(issues, Issue{
+			ID:           issueID(kind, "data_source", "url"),
+			Severity:     SeverityBlocking,
+			DataSource:   kind,
+			ExpectedType: expectedURL,
+			ActualType:   ds.URL,
+			Message:      fmt.Sprintf("%s data source url %q does not match configured url %q", kind, ds.URL, expectedURL),
+		})
+	}
+	if len(ds.Schema) == 0 {
+		issues = append(issues, Issue{
+			ID:         issueID(kind, "schema", "missing"),
+			Severity:   SeverityBlocking,
+			DataSource: kind,
+			Message:    fmt.Sprintf("%s data source snapshot is missing schema", kind),
+		})
+	}
+	return issues
+}
+
+func validateRequirement(ds DataSource, req requirement) (Issue, Repair, bool) {
+	prop, ok := ds.Schema[req.property]
+	if !ok {
+		if req.blocking {
+			return Issue{
+				ID:           issueID(req.dataSource, req.property, "missing"),
+				Severity:     SeverityBlocking,
+				DataSource:   req.dataSource,
+				Property:     req.property,
+				ExpectedType: req.typ,
+				Message:      fmt.Sprintf("%s data source is missing required %q property of type %q", req.dataSource, req.property, req.typ),
+			}, Repair{}, true
+		}
+		repair := Repair{
+			ID:               issueID(req.dataSource, req.property, "add"),
+			DataSource:       req.dataSource,
+			DataSourceURL:    ds.URL,
+			Property:         req.property,
+			Type:             req.typ,
+			Statement:        req.statement,
+			RequiresApproval: true,
+		}
+		return Issue{
+			ID:              repair.ID,
+			Severity:        SeverityFixable,
+			DataSource:      req.dataSource,
+			Property:        req.property,
+			ExpectedType:    req.typ,
+			Message:         fmt.Sprintf("%s data source can add missing %q property of type %q", req.dataSource, req.property, req.typ),
+			Repairable:      true,
+			RepairStatement: req.statement,
+		}, repair, true
+	}
+
+	if prop.Type != req.typ {
+		return Issue{
+			ID:           issueID(req.dataSource, req.property, "type"),
+			Severity:     SeverityBlocking,
+			DataSource:   req.dataSource,
+			Property:     req.property,
+			ExpectedType: req.typ,
+			ActualType:   prop.Type,
+			Message:      fmt.Sprintf("%s data source property %q has type %q, expected %q", req.dataSource, req.property, prop.Type, req.typ),
+		}, Repair{}, true
+	}
+
+	if req.target != "" && prop.DataSourceURL != "" && prop.DataSourceURL != req.target {
+		return Issue{
+			ID:           issueID(req.dataSource, req.property, "relation_target"),
+			Severity:     SeverityBlocking,
+			DataSource:   req.dataSource,
+			Property:     req.property,
+			ExpectedType: req.target,
+			ActualType:   prop.DataSourceURL,
+			Message:      fmt.Sprintf("%s data source relation %q targets %q, expected %q", req.dataSource, req.property, prop.DataSourceURL, req.target),
+		}, Repair{}, true
+	}
+
+	return Issue{}, Repair{}, false
+}
+
+func issueID(dataSource, property, suffix string) string {
+	return fmt.Sprintf("%s.%s.%s", dataSource, sanitizeIDPart(property), suffix)
+}
+
+func sanitizeIDPart(s string) string {
+	out := make([]rune, 0, len(s))
+	lastDash := false
+	for _, r := range s {
+		switch {
+		case r >= 'A' && r <= 'Z':
+			out = append(out, r+'a'-'A')
+			lastDash = false
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'):
+			out = append(out, r)
+			lastDash = false
+		default:
+			if !lastDash {
+				out = append(out, '-')
+				lastDash = true
+			}
+		}
+	}
+	for len(out) > 0 && out[len(out)-1] == '-' {
+		out = out[:len(out)-1]
+	}
+	if len(out) == 0 {
+		return "property"
+	}
+	return string(out)
+}
+
+func sortIssues(issues []Issue) {
+	sort.Slice(issues, func(i, j int) bool {
+		return issues[i].ID < issues[j].ID
+	})
+}
+
+func sortRepairs(repairs []Repair) {
+	sort.Slice(repairs, func(i, j int) bool {
+		return repairs[i].ID < repairs[j].ID
+	})
+}
+
+func cloneDataSource(ds DataSource) DataSource {
+	cloned := DataSource{Name: ds.Name, URL: ds.URL, Schema: map[string]Property{}}
+	for k, v := range ds.Schema {
+		cloned.Schema[k] = v
+	}
+	return cloned
+}

--- a/internal/notion/schema/schema_test.go
+++ b/internal/notion/schema/schema_test.go
@@ -1,0 +1,130 @@
+package schema
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func compatibleSpecsSnapshot() DataSource {
+	return DataSource{
+		Name: "Specs",
+		URL:  "collection://specs",
+		Schema: map[string]Property{
+			"Name":        {Name: "Name", Type: TypeTitle},
+			"Spec ID":     {Name: "Spec ID", Type: TypeAutoIncrementID},
+			"Created":     {Name: "Created", Type: TypeCreatedTime},
+			"Last Edited": {Name: "Last Edited", Type: TypeLastEditedTime},
+			"Status":      {Name: "Status", Type: TypeSelect},
+			"Approval":    {Name: "Approval", Type: TypeSelect},
+			"Tags":        {Name: "Tags", Type: TypeMultiSelect},
+			"Author":      {Name: "Author", Type: TypePerson},
+			"Reviewers":   {Name: "Reviewers", Type: TypePerson},
+			"Plan":        {Name: "Plan", Type: TypeRelation, DataSourceURL: "collection://plans"},
+		},
+	}
+}
+
+func compatiblePlansSnapshot() DataSource {
+	return DataSource{
+		Name: "Plans",
+		URL:  "collection://plans",
+		Schema: map[string]Property{
+			"Name":          {Name: "Name", Type: TypeTitle},
+			"Plan ID":       {Name: "Plan ID", Type: TypeAutoIncrementID},
+			"Created":       {Name: "Created", Type: TypeCreatedTime},
+			"Last Edited":   {Name: "Last Edited", Type: TypeLastEditedTime},
+			"Status":        {Name: "Status", Type: TypeSelect},
+			"Approval":      {Name: "Approval", Type: TypeSelect},
+			"Tags":          {Name: "Tags", Type: TypeMultiSelect},
+			"Author":        {Name: "Author", Type: TypePerson},
+			"Reviewers":     {Name: "Reviewers", Type: TypePerson},
+			"Spec":          {Name: "Spec", Type: TypeRelation, DataSourceURL: "collection://specs"},
+			"Linear Issues": {Name: "Linear Issues", Type: TypeURL},
+		},
+	}
+}
+
+func validationOptions() ValidationOptions {
+	return ValidationOptions{
+		SpecsDataSource: "collection://specs",
+		PlansDataSource: "collection://plans",
+		SpecIDProperty:  "Spec ID",
+		PlanIDProperty:  "Plan ID",
+	}
+}
+
+func TestValidatePair_CompatibleSnapshotsPass(t *testing.T) {
+	report := ValidatePair(compatibleSpecsSnapshot(), compatiblePlansSnapshot(), validationOptions())
+
+	require.True(t, report.Valid)
+	require.Empty(t, report.BlockingIssues)
+	require.Empty(t, report.FixableIssues)
+	require.Empty(t, report.Repairs)
+}
+
+func TestValidatePair_MissingRequiredIDFieldsAreBlocking(t *testing.T) {
+	specs := compatibleSpecsSnapshot()
+	delete(specs.Schema, "Spec ID")
+
+	report := ValidatePair(specs, compatiblePlansSnapshot(), validationOptions())
+
+	require.False(t, report.Valid)
+	require.Len(t, report.BlockingIssues, 1)
+	require.Equal(t, "specs.spec-id.missing", report.BlockingIssues[0].ID)
+	require.Equal(t, TypeAutoIncrementID, report.BlockingIssues[0].ExpectedType)
+	require.Empty(t, report.Repairs)
+}
+
+func TestValidatePair_MissingSafePropertiesAreFixable(t *testing.T) {
+	specs := compatibleSpecsSnapshot()
+	plans := compatiblePlansSnapshot()
+	delete(specs.Schema, "Tags")
+	delete(plans.Schema, "Linear Issues")
+
+	report := ValidatePair(specs, plans, validationOptions())
+
+	require.False(t, report.Valid)
+	require.Empty(t, report.BlockingIssues)
+	require.Len(t, report.FixableIssues, 2)
+	require.Len(t, report.Repairs, 2)
+	require.Equal(t, "plans.linear-issues.add", report.Repairs[0].ID)
+	require.Equal(t, "specs.tags.add", report.Repairs[1].ID)
+
+	updatedSpecs, updatedPlans, applied := ApplyApprovedRepairs(specs, plans, report.Repairs, []string{"specs.tags.add", "plans.linear-issues.add"})
+	require.Len(t, applied, 2)
+	after := ValidatePair(updatedSpecs, updatedPlans, validationOptions())
+	require.True(t, after.Valid)
+}
+
+func TestValidatePair_IncompatiblePropertyTypesAreBlocking(t *testing.T) {
+	specs := compatibleSpecsSnapshot()
+	specs.Schema["Status"] = Property{Name: "Status", Type: TypeURL}
+
+	report := ValidatePair(specs, compatiblePlansSnapshot(), validationOptions())
+
+	require.False(t, report.Valid)
+	require.Len(t, report.BlockingIssues, 1)
+	require.Equal(t, "specs.status.type", report.BlockingIssues[0].ID)
+	require.Empty(t, report.Repairs)
+}
+
+func TestParseDataSource_ReadsNotionMCPFetchWrapper(t *testing.T) {
+	direct := compatibleSpecsSnapshot()
+	directJSON, err := json.Marshal(direct)
+	require.NoError(t, err)
+	mcpState := `<data-source-state>` + string(directJSON) + `</data-source-state>`
+	inner, err := json.Marshal(map[string]any{
+		"metadata": map[string]any{"type": "data_source"},
+		"text":     mcpState,
+	})
+	require.NoError(t, err)
+	wrapper, err := json.Marshal([]map[string]string{{"type": "text", "text": string(inner)}})
+	require.NoError(t, err)
+
+	parsed, err := ParseDataSource(wrapper)
+	require.NoError(t, err)
+	require.Equal(t, direct.URL, parsed.URL)
+	require.Equal(t, TypeAutoIncrementID, parsed.Schema["Spec ID"].Type)
+}

--- a/internal/notion/setup/instructions.go
+++ b/internal/notion/setup/instructions.go
@@ -1,0 +1,84 @@
+package setup
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/jumppad-labs/spektacular/internal/notion/schema"
+)
+
+// Instruction describes an MCP action for an agent to perform.
+type Instruction struct {
+	Tool          string `json:"tool"`
+	DataSource    string `json:"data_source,omitempty"`
+	DataSourceURL string `json:"data_source_url,omitempty"`
+	Statement     string `json:"statement,omitempty"`
+	Title         string `json:"title,omitempty"`
+	Schema        string `json:"schema,omitempty"`
+	Description   string `json:"description"`
+}
+
+// RepairInstructions converts approved repairs into Notion MCP update steps.
+func RepairInstructions(repairs []schema.Repair) []Instruction {
+	instructions := make([]Instruction, 0, len(repairs))
+	for _, repair := range repairs {
+		instructions = append(instructions, Instruction{
+			Tool:          "notion_update_data_source",
+			DataSource:    repair.DataSource,
+			DataSourceURL: repair.DataSourceURL,
+			Statement:     repair.Statement,
+			Description:   fmt.Sprintf("Apply approved additive repair %s for %s.%s.", repair.ID, repair.DataSource, repair.Property),
+		})
+	}
+	return instructions
+}
+
+// CreateDatabaseInstructions returns MCP create steps for a managed initial setup.
+func CreateDatabaseInstructions(basePageURL string) []Instruction {
+	parent := "the chosen Notion parent page"
+	if basePageURL != "" {
+		parent = basePageURL
+	}
+
+	return []Instruction{
+		{
+			Tool:        "notion_create_database",
+			Title:       "Specs",
+			Schema:      specsDatabaseDDL(),
+			Description: fmt.Sprintf("Create the Specs data source under %s, then fetch it and pass the resulting data-source snapshot to `spektacular notion link`.", parent),
+		},
+		{
+			Tool:        "notion_create_database",
+			Title:       "Plans",
+			Schema:      plansDatabaseDDL(),
+			Description: fmt.Sprintf("Create the Plans data source under %s, then fetch it and pass the resulting data-source snapshot to `spektacular notion link`.", parent),
+		},
+	}
+}
+
+func specsDatabaseDDL() string {
+	cols := []string{
+		`"Name" TITLE`,
+		`"Spec ID" UNIQUE_ID PREFIX 'SPEC'`,
+		`"Status" SELECT('Drafting':gray, 'In Review':yellow, 'Approved':green, 'Building':blue, 'Shipped':purple, 'Superseded':red)`,
+		`"Approval" SELECT('Draft':gray, 'Approved':green)`,
+		`"Tags" MULTI_SELECT('security':red, 'compliance':orange, 'platform':blue, 'infra':purple, 'growth':green, 'developer-experience':yellow, 'ai':pink)`,
+		`"Author" PEOPLE`,
+		`"Reviewers" PEOPLE`,
+	}
+	return "CREATE TABLE (" + strings.Join(cols, ", ") + ")"
+}
+
+func plansDatabaseDDL() string {
+	cols := []string{
+		`"Name" TITLE`,
+		`"Plan ID" UNIQUE_ID PREFIX 'PLAN'`,
+		`"Status" SELECT('Drafting':gray, 'In Review':yellow, 'Approved':green, 'Building':blue, 'Shipped':purple, 'Superseded':red)`,
+		`"Approval" SELECT('Draft':gray, 'Approved':green)`,
+		`"Tags" MULTI_SELECT('security':red, 'compliance':orange, 'platform':blue, 'infra':purple, 'growth':green, 'developer-experience':yellow, 'ai':pink)`,
+		`"Author" PEOPLE`,
+		`"Reviewers" PEOPLE`,
+		`"Linear Issues" URL`,
+	}
+	return "CREATE TABLE (" + strings.Join(cols, ", ") + ")"
+}

--- a/internal/project/init.go
+++ b/internal/project/init.go
@@ -5,29 +5,60 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 
 	"github.com/jumppad-labs/spektacular/internal/config"
 	"github.com/jumppad-labs/spektacular/templates"
 )
 
+// InitOptions configures Spektacular project initialisation.
+type InitOptions struct {
+	Force                   bool
+	Config                  config.Config
+	CreateLocalArtifactDirs bool
+	CreateNotionCacheDir    bool
+}
+
 // Init creates the .spektacular directory structure in projectPath.
 // If force is false and the directory already exists, an error is returned.
 func Init(projectPath string, force bool) error {
+	return InitWithOptions(projectPath, InitOptions{
+		Force:                   force,
+		Config:                  config.NewDefault(),
+		CreateLocalArtifactDirs: true,
+	})
+}
+
+// InitWithOptions creates the .spektacular directory structure in projectPath
+// using mode-specific artifact directory options.
+func InitWithOptions(projectPath string, opts InitOptions) error {
 	spektacularDir := filepath.Join(projectPath, ".spektacular")
 
-	if _, err := os.Stat(spektacularDir); err == nil && !force {
+	if _, err := os.Stat(spektacularDir); err == nil && !opts.Force {
 		return fmt.Errorf(".spektacular directory already exists at %s; use --force to overwrite", spektacularDir)
+	}
+
+	cfg := opts.Config
+	if reflect.DeepEqual(cfg, config.Config{}) {
+		cfg = config.NewDefault()
 	}
 
 	dirs := []string{
 		spektacularDir,
-		filepath.Join(spektacularDir, "plans"),
-		filepath.Join(spektacularDir, "specs"),
 		filepath.Join(spektacularDir, "knowledge"),
 		filepath.Join(spektacularDir, "knowledge", "learnings"),
 		filepath.Join(spektacularDir, "knowledge", "architecture"),
 		filepath.Join(spektacularDir, "knowledge", "gotchas"),
+	}
+	if opts.CreateLocalArtifactDirs {
+		dirs = append(dirs,
+			filepath.Join(spektacularDir, "plans"),
+			filepath.Join(spektacularDir, "specs"),
+		)
+	}
+	if opts.CreateNotionCacheDir {
+		dirs = append(dirs, filepath.Join(spektacularDir, cfg.Artifacts.CacheDir))
 	}
 	for _, d := range dirs {
 		if err := os.MkdirAll(d, 0755); err != nil {
@@ -38,7 +69,6 @@ func Init(projectPath string, force bool) error {
 	// Write default config.yaml only if it does not already exist.
 	configPath := filepath.Join(spektacularDir, "config.yaml")
 	if _, err := os.Stat(configPath); os.IsNotExist(err) {
-		cfg := config.NewDefault()
 		if err := cfg.ToYAMLFile(configPath); err != nil {
 			return fmt.Errorf("writing config: %w", err)
 		}

--- a/internal/project/init_test.go
+++ b/internal/project/init_test.go
@@ -44,6 +44,38 @@ func TestInit_CreatesConfigFile(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "timestamp", cfg.Spec.IDMethod)
 	require.Equal(t, 0, cfg.Spec.Counter)
+	require.Equal(t, "local", cfg.Artifacts.Backend)
+	require.Equal(t, "cache/notion", cfg.Artifacts.CacheDir)
+}
+
+func TestInitWithOptions_NotionModeOmitsLocalArtifactDirsAndCreatesCache(t *testing.T) {
+	dir := t.TempDir()
+	cfg := config.NewDefault()
+	cfg.Spec.IDMethod = config.SpecIDMethodExternal
+	cfg.Artifacts.Backend = config.ArtifactBackendNotion
+	cfg.Artifacts.Notion.BasePageURL = "https://notion.example/base"
+	cfg.Artifacts.Notion.SpecsDataSource = "collection://specs"
+	cfg.Artifacts.Notion.PlansDataSource = "collection://plans"
+
+	err := InitWithOptions(dir, InitOptions{
+		Config:               cfg,
+		CreateNotionCacheDir: true,
+	})
+	require.NoError(t, err)
+
+	require.NoDirExists(t, filepath.Join(dir, ".spektacular", "plans"))
+	require.NoDirExists(t, filepath.Join(dir, ".spektacular", "specs"))
+	require.DirExists(t, filepath.Join(dir, ".spektacular", "cache", "notion"))
+	require.DirExists(t, filepath.Join(dir, ".spektacular", "knowledge"))
+
+	loaded, err := config.FromYAMLFile(filepath.Join(dir, ".spektacular", "config.yaml"))
+	require.NoError(t, err)
+	require.Equal(t, config.ArtifactBackendNotion, loaded.Artifacts.Backend)
+	require.Equal(t, config.SpecIDMethodExternal, loaded.Spec.IDMethod)
+	require.Equal(t, "collection://specs", loaded.Artifacts.Notion.SpecsDataSource)
+	require.Equal(t, "collection://plans", loaded.Artifacts.Notion.PlansDataSource)
+	require.Equal(t, "Spec ID", loaded.Artifacts.Notion.SpecIDProperty)
+	require.Equal(t, "Plan ID", loaded.Artifacts.Notion.PlanIDProperty)
 }
 
 func TestInit_CreatesGitignore(t *testing.T) {
@@ -52,8 +84,9 @@ func TestInit_CreatesGitignore(t *testing.T) {
 	require.NoError(t, err)
 
 	gitignorePath := filepath.Join(dir, ".spektacular", ".gitignore")
-	_, err = os.Stat(gitignorePath)
+	data, err := os.ReadFile(gitignorePath)
 	require.NoError(t, err)
+	require.Contains(t, string(data), "cache/notion/")
 }
 
 func TestInit_CreatesConventionsMd(t *testing.T) {

--- a/internal/project/init_test.go
+++ b/internal/project/init_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/jumppad-labs/spektacular/internal/config"
 	"github.com/stretchr/testify/require"
 )
 
@@ -38,6 +39,11 @@ func TestInit_CreatesConfigFile(t *testing.T) {
 	configPath := filepath.Join(dir, ".spektacular", "config.yaml")
 	_, err = os.Stat(configPath)
 	require.NoError(t, err, "config.yaml should exist")
+
+	cfg, err := config.FromYAMLFile(configPath)
+	require.NoError(t, err)
+	require.Equal(t, "timestamp", cfg.Spec.IDMethod)
+	require.Equal(t, 0, cfg.Spec.Counter)
 }
 
 func TestInit_CreatesGitignore(t *testing.T) {

--- a/internal/stepkit/stepkit.go
+++ b/internal/stepkit/stepkit.go
@@ -29,6 +29,11 @@ type PathStrategy interface {
 	PrimaryPathField() string
 }
 
+// ConfigPathStrategy can opt into workflow config-aware path generation.
+type ConfigPathStrategy interface {
+	PathVarsWithConfig(instanceName, storeRoot string, cfg workflow.Config) map[string]any
+}
+
 // StepRequest bundles the inputs to WriteStepResult.
 type StepRequest struct {
 	StepName     string
@@ -74,6 +79,9 @@ func WriteStepResult(
 		storeRoot = st.Root()
 	}
 	pathVars := req.Strategy.PathVars(instanceName, storeRoot)
+	if strategy, ok := req.Strategy.(ConfigPathStrategy); ok {
+		pathVars = strategy.PathVarsWithConfig(instanceName, storeRoot, cfg)
+	}
 
 	vars := map[string]any{
 		"step":      req.StepName,

--- a/internal/steps/implement/strategy.go
+++ b/internal/steps/implement/strategy.go
@@ -3,7 +3,9 @@ package implement
 import (
 	"path/filepath"
 
+	"github.com/jumppad-labs/spektacular/internal/artifact"
 	"github.com/jumppad-labs/spektacular/internal/stepkit"
+	"github.com/jumppad-labs/spektacular/internal/workflow"
 )
 
 // PlanFilePath returns the store-relative path for a plan's plan.md file.
@@ -37,6 +39,30 @@ func (strategy) PathVars(instanceName, storeRoot string) map[string]any {
 		"context_path":           contextPath,
 		"research_path":          researchPath,
 		"plan_dir":               filepath.Dir(planPath),
+		"plan_name":              instanceName,
+		"changelog_section_name": "## Changelog",
+	}
+}
+
+func (s strategy) PathVarsWithConfig(instanceName, storeRoot string, cfg workflow.Config) map[string]any {
+	planPath, err := artifact.Path(cfg.Project, artifact.KindPlan, instanceName)
+	if err != nil {
+		return s.PathVars(instanceName, storeRoot)
+	}
+	contextPath, err := artifact.Path(cfg.Project, artifact.KindContext, instanceName)
+	if err != nil {
+		return s.PathVars(instanceName, storeRoot)
+	}
+	researchPath, err := artifact.Path(cfg.Project, artifact.KindResearch, instanceName)
+	if err != nil {
+		return s.PathVars(instanceName, storeRoot)
+	}
+	planAbsPath := filepath.Join(storeRoot, planPath)
+	return map[string]any{
+		"plan_path":              planAbsPath,
+		"context_path":           filepath.Join(storeRoot, contextPath),
+		"research_path":          filepath.Join(storeRoot, researchPath),
+		"plan_dir":               filepath.Dir(planAbsPath),
 		"plan_name":              instanceName,
 		"changelog_section_name": "## Changelog",
 	}

--- a/internal/steps/plan/steps.go
+++ b/internal/steps/plan/steps.go
@@ -3,6 +3,8 @@ package plan
 import (
 	"fmt"
 
+	"github.com/jumppad-labs/spektacular/internal/artifact"
+	"github.com/jumppad-labs/spektacular/internal/config"
 	"github.com/jumppad-labs/spektacular/internal/stepkit"
 	"github.com/jumppad-labs/spektacular/internal/store"
 	"github.com/jumppad-labs/spektacular/internal/workflow"
@@ -21,6 +23,10 @@ func ContextFilePath(name string) string {
 // ResearchFilePath returns the store-relative path for a plan's research file.
 func ResearchFilePath(name string) string {
 	return "plans/" + name + "/research.md"
+}
+
+func planArtifactPath(cfg workflow.Config, kind, name string) (string, error) {
+	return artifact.Path(cfg.Project, kind, name)
 }
 
 // Steps returns the ordered step configs for a plan workflow.
@@ -184,7 +190,14 @@ func writePlan() workflow.StepCallback {
 			return "", fmt.Errorf("plan_template missing — submit the filled plan.md via --file or --stdin plan_template")
 		}
 		if !cfg.DryRun {
-			if err := st.Write(PlanFilePath(planName), []byte(content)); err != nil {
+			planPath, err := planArtifactPath(cfg, artifact.KindPlan, planName)
+			if err != nil {
+				return "", err
+			}
+			if err := st.Write(planPath, []byte(content)); err != nil {
+				return "", err
+			}
+			if err := recordPlanRemote(data, st, cfg, artifact.KindPlan, planName, "remote", []byte(content)); err != nil {
 				return "", err
 			}
 		}
@@ -201,7 +214,14 @@ func writeContext() workflow.StepCallback {
 			return "", fmt.Errorf("context_template missing — submit the filled context.md via --file or --stdin context_template")
 		}
 		if !cfg.DryRun {
-			if err := st.Write(ContextFilePath(planName), []byte(content)); err != nil {
+			contextPath, err := planArtifactPath(cfg, artifact.KindContext, planName)
+			if err != nil {
+				return "", err
+			}
+			if err := st.Write(contextPath, []byte(content)); err != nil {
+				return "", err
+			}
+			if err := recordPlanRemote(data, st, cfg, artifact.KindContext, planName, "context_remote", []byte(content)); err != nil {
 				return "", err
 			}
 		}
@@ -218,7 +238,14 @@ func writeResearch() workflow.StepCallback {
 			return "", fmt.Errorf("research_template missing — submit the filled research.md via --file or --stdin research_template")
 		}
 		if !cfg.DryRun {
-			if err := st.Write(ResearchFilePath(planName), []byte(content)); err != nil {
+			researchPath, err := planArtifactPath(cfg, artifact.KindResearch, planName)
+			if err != nil {
+				return "", err
+			}
+			if err := st.Write(researchPath, []byte(content)); err != nil {
+				return "", err
+			}
+			if err := recordPlanRemote(data, st, cfg, artifact.KindResearch, planName, "research_remote", []byte(content)); err != nil {
 				return "", err
 			}
 		}
@@ -232,11 +259,41 @@ func finished() workflow.StepCallback {
 			return "", writeStep("finished", "", "steps/plan/17-finished.md", data, out, st, cfg, nil)
 		}
 		planName := stepkit.GetString(data, "name")
-		for _, p := range []string{PlanFilePath(planName), ContextFilePath(planName), ResearchFilePath(planName)} {
+		paths := make([]string, 0, 3)
+		for _, kind := range []string{artifact.KindPlan, artifact.KindContext, artifact.KindResearch} {
+			path, err := planArtifactPath(cfg, kind, planName)
+			if err != nil {
+				return "", err
+			}
+			paths = append(paths, path)
+		}
+		for _, p := range paths {
 			if !st.Exists(p) {
 				return "", fmt.Errorf("expected file %s not found — the preceding write step should have written it", p)
 			}
 		}
 		return "", writeStep("finished", "", "steps/plan/17-finished.md", data, out, st, cfg, nil)
 	}
+}
+
+func recordPlanRemote(data workflow.Data, st store.Store, cfg workflow.Config, kind, name, key string, content []byte) error {
+	if cfg.Project.Artifacts.Backend != config.ArtifactBackendNotion {
+		return nil
+	}
+	value, ok := data.Get(key)
+	if !ok || value == nil {
+		return fmt.Errorf("%s metadata is required in Notion mode", key)
+	}
+	remote, _, err := artifact.RemoteMetadataFromAny(value)
+	if err != nil {
+		return fmt.Errorf("reading %s metadata: %w", key, err)
+	}
+	if err := artifact.ValidateRemoteMetadata(remote); err != nil {
+		return err
+	}
+	if _, err := artifact.RecordPull(st, cfg.Project, kind, name, content, remote); err != nil {
+		return err
+	}
+	data.Set(key, nil)
+	return nil
 }

--- a/internal/steps/plan/strategy.go
+++ b/internal/steps/plan/strategy.go
@@ -3,7 +3,9 @@ package plan
 import (
 	"path/filepath"
 
+	"github.com/jumppad-labs/spektacular/internal/artifact"
 	"github.com/jumppad-labs/spektacular/internal/stepkit"
+	"github.com/jumppad-labs/spektacular/internal/workflow"
 )
 
 // strategy implements stepkit.PathStrategy for the plan workflow.
@@ -24,6 +26,35 @@ func (strategy) PathVars(instanceName, storeRoot string) map[string]any {
 		"plan_dir":      filepath.Dir(planPath),
 		"plan_name":     instanceName,
 		"spec_path":     specPath,
+	}
+}
+
+func (s strategy) PathVarsWithConfig(instanceName, storeRoot string, cfg workflow.Config) map[string]any {
+	planPath, err := artifact.Path(cfg.Project, artifact.KindPlan, instanceName)
+	if err != nil {
+		return s.PathVars(instanceName, storeRoot)
+	}
+	contextPath, err := artifact.Path(cfg.Project, artifact.KindContext, instanceName)
+	if err != nil {
+		return s.PathVars(instanceName, storeRoot)
+	}
+	researchPath, err := artifact.Path(cfg.Project, artifact.KindResearch, instanceName)
+	if err != nil {
+		return s.PathVars(instanceName, storeRoot)
+	}
+	specPath, err := artifact.Path(cfg.Project, artifact.KindSpec, instanceName)
+	if err != nil {
+		return s.PathVars(instanceName, storeRoot)
+	}
+
+	planAbsPath := filepath.Join(storeRoot, planPath)
+	return map[string]any{
+		"plan_path":     planAbsPath,
+		"context_path":  filepath.Join(storeRoot, contextPath),
+		"research_path": filepath.Join(storeRoot, researchPath),
+		"plan_dir":      filepath.Dir(planAbsPath),
+		"plan_name":     instanceName,
+		"spec_path":     filepath.Join(storeRoot, specPath),
 	}
 }
 

--- a/internal/steps/spec/identifier.go
+++ b/internal/steps/spec/identifier.go
@@ -1,0 +1,192 @@
+package spec
+
+import (
+	"fmt"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/jumppad-labs/spektacular/internal/config"
+	"github.com/jumppad-labs/spektacular/internal/store"
+)
+
+const (
+	IDMethodTimestamp = config.SpecIDMethodTimestamp
+	IDMethodCounter   = config.SpecIDMethodCounter
+	IDMethodExternal  = config.SpecIDMethodExternal
+
+	MaxIdentifierPartLength = 64
+)
+
+// IdentifierRequest describes the data needed to resolve a canonical spec name.
+type IdentifierRequest struct {
+	Name    string
+	ID      string
+	Method  string
+	Counter int
+	Store   store.Store
+	Now     func() time.Time
+}
+
+// IdentifierResult is the canonical spec name and any updated counter state.
+type IdentifierResult struct {
+	Name    string
+	Counter int
+}
+
+// ResolveIdentifier turns a requested spec name plus optional id into a
+// canonical spec name.
+func ResolveIdentifier(req IdentifierRequest) (IdentifierResult, error) {
+	name, err := NormalizeIdentifierPart("name", req.Name)
+	if err != nil {
+		return IdentifierResult{}, err
+	}
+
+	method := req.Method
+	if method == "" {
+		method = IDMethodTimestamp
+	}
+	if err := validateMethod(method); err != nil {
+		return IdentifierResult{}, err
+	}
+
+	if req.ID != "" {
+		id, err := NormalizeIdentifierPart("id", req.ID)
+		if err != nil {
+			return IdentifierResult{}, err
+		}
+		resolved, err := resolveWithPrefix(req.Store, id, name)
+		if err != nil {
+			return IdentifierResult{}, err
+		}
+		return IdentifierResult{Name: resolved, Counter: req.Counter}, nil
+	}
+
+	switch method {
+	case IDMethodExternal:
+		return IdentifierResult{}, fmt.Errorf("id is required when spec.id_method is %q", IDMethodExternal)
+	case IDMethodTimestamp:
+		return resolveTimestamp(req, name)
+	case IDMethodCounter:
+		return resolveCounter(req, name)
+	default:
+		return IdentifierResult{}, fmt.Errorf("unsupported spec.id_method %q", method)
+	}
+}
+
+// NormalizeIdentifierPart normalizes one user-provided name/id component.
+func NormalizeIdentifierPart(label, raw string) (string, error) {
+	if raw == "" {
+		return "", fmt.Errorf("%s is required", label)
+	}
+	if len(raw) > MaxIdentifierPartLength {
+		return "", fmt.Errorf("%s must be at most %d characters", label, MaxIdentifierPartLength)
+	}
+	if raw != strings.TrimSpace(raw) {
+		return "", fmt.Errorf("%s must not have leading or trailing whitespace", label)
+	}
+
+	var b strings.Builder
+	lastHyphen := false
+	for _, r := range raw {
+		switch {
+		case r == '/' || r == '\\':
+			return "", fmt.Errorf("%s must not contain path separators", label)
+		case unicode.IsControl(r):
+			return "", fmt.Errorf("%s must not contain control characters", label)
+		case isASCIIAlnum(r):
+			b.WriteRune(toASCIILower(r))
+			lastHyphen = false
+		case r == '_':
+			b.WriteRune(r)
+			lastHyphen = false
+		case unicode.IsSpace(r) || unicode.IsPunct(r) || unicode.IsSymbol(r):
+			if !lastHyphen {
+				b.WriteByte('-')
+				lastHyphen = true
+			}
+		default:
+			return "", fmt.Errorf("%s contains unsupported character %q", label, r)
+		}
+	}
+
+	out := b.String()
+	if out == "" {
+		return "", fmt.Errorf("%s normalizes to empty", label)
+	}
+	return out, nil
+}
+
+func validateMethod(method string) error {
+	switch method {
+	case IDMethodTimestamp, IDMethodCounter, IDMethodExternal:
+		return nil
+	default:
+		return fmt.Errorf("unsupported spec.id_method %q", method)
+	}
+}
+
+func resolveTimestamp(req IdentifierRequest, name string) (IdentifierResult, error) {
+	now := req.Now
+	if now == nil {
+		now = time.Now
+	}
+
+	timestamp := now().UTC()
+	for {
+		resolved := fmt.Sprintf("%s-%s", timestamp.Format("20060102150405"), name)
+		exists, err := specExists(req.Store, resolved)
+		if err != nil {
+			return IdentifierResult{}, err
+		}
+		if !exists {
+			return IdentifierResult{Name: resolved, Counter: req.Counter}, nil
+		}
+		timestamp = timestamp.Add(time.Second)
+	}
+}
+
+func resolveCounter(req IdentifierRequest, name string) (IdentifierResult, error) {
+	counter := req.Counter + 1
+	for {
+		resolved := fmt.Sprintf("%06d-%s", counter, name)
+		exists, err := specExists(req.Store, resolved)
+		if err != nil {
+			return IdentifierResult{}, err
+		}
+		if !exists {
+			return IdentifierResult{Name: resolved, Counter: counter}, nil
+		}
+		counter++
+	}
+}
+
+func resolveWithPrefix(st store.Store, prefix, name string) (string, error) {
+	resolved := fmt.Sprintf("%s-%s", prefix, name)
+	exists, err := specExists(st, resolved)
+	if err != nil {
+		return "", err
+	}
+	if exists {
+		return "", fmt.Errorf("spec %q already exists", resolved)
+	}
+	return resolved, nil
+}
+
+func specExists(st store.Store, name string) (bool, error) {
+	if st == nil {
+		return false, fmt.Errorf("store required for spec identifier resolution")
+	}
+	return st.Exists(SpecFilePath(name)), nil
+}
+
+func isASCIIAlnum(r rune) bool {
+	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9')
+}
+
+func toASCIILower(r rune) rune {
+	if r >= 'A' && r <= 'Z' {
+		return r + ('a' - 'A')
+	}
+	return r
+}

--- a/internal/steps/spec/identifier_test.go
+++ b/internal/steps/spec/identifier_test.go
@@ -1,0 +1,228 @@
+package spec
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jumppad-labs/spektacular/internal/store"
+	"github.com/stretchr/testify/require"
+)
+
+func identifierStore(t *testing.T) store.Store {
+	t.Helper()
+	return store.NewFileStore(t.TempDir())
+}
+
+func writeExistingSpec(t *testing.T, st store.Store, name string) {
+	t.Helper()
+	require.NoError(t, st.Write(SpecFilePath(name), []byte("existing")))
+}
+
+func fixedIdentifierTime() time.Time {
+	return time.Date(2026, time.May, 8, 21, 2, 3, 0, time.FixedZone("EDT", -4*60*60))
+}
+
+func TestResolveIdentifier_DefaultTimestamp(t *testing.T) {
+	st := identifierStore(t)
+
+	got, err := ResolveIdentifier(IdentifierRequest{
+		Name:  "Billing.Export",
+		Store: st,
+		Now:   fixedIdentifierTime,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "20260509010203-billing-export", got.Name)
+	require.Equal(t, 0, got.Counter)
+}
+
+func TestResolveIdentifier_TimestampCollisionBumpsSeconds(t *testing.T) {
+	st := identifierStore(t)
+	writeExistingSpec(t, st, "20260509010203-billing-export")
+
+	got, err := ResolveIdentifier(IdentifierRequest{
+		Name:   "billing-export",
+		Method: IDMethodTimestamp,
+		Store:  st,
+		Now:    fixedIdentifierTime,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "20260509010204-billing-export", got.Name)
+	require.Equal(t, 0, got.Counter)
+}
+
+func TestResolveIdentifier_ExplicitTimestampMethod(t *testing.T) {
+	st := identifierStore(t)
+
+	got, err := ResolveIdentifier(IdentifierRequest{
+		Name:   "Billing@Export",
+		Method: IDMethodTimestamp,
+		Store:  st,
+		Now:    fixedIdentifierTime,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "20260509010203-billing-export", got.Name)
+}
+
+func TestResolveIdentifier_CounterUsesNextValue(t *testing.T) {
+	st := identifierStore(t)
+
+	got, err := ResolveIdentifier(IdentifierRequest{
+		Name:    "billing-export",
+		Method:  IDMethodCounter,
+		Counter: 7,
+		Store:   st,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "000008-billing-export", got.Name)
+	require.Equal(t, 8, got.Counter)
+}
+
+func TestResolveIdentifier_CounterCollisionBumpsValue(t *testing.T) {
+	st := identifierStore(t)
+	writeExistingSpec(t, st, "000008-billing-export")
+
+	got, err := ResolveIdentifier(IdentifierRequest{
+		Name:    "billing-export",
+		Method:  IDMethodCounter,
+		Counter: 7,
+		Store:   st,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "000009-billing-export", got.Name)
+	require.Equal(t, 9, got.Counter)
+}
+
+func TestResolveIdentifier_ExplicitIDOverridesGeneratedMethod(t *testing.T) {
+	st := identifierStore(t)
+
+	got, err := ResolveIdentifier(IdentifierRequest{
+		Name:    "Billing Export",
+		ID:      "EXT.User@123",
+		Method:  IDMethodCounter,
+		Counter: 7,
+		Store:   st,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "ext-user-123-billing-export", got.Name)
+	require.Equal(t, 7, got.Counter)
+}
+
+func TestResolveIdentifier_ExplicitIDCollisionFails(t *testing.T) {
+	st := identifierStore(t)
+	writeExistingSpec(t, st, "ext-123-billing")
+
+	_, err := ResolveIdentifier(IdentifierRequest{
+		Name:  "billing",
+		ID:    "EXT.123",
+		Store: st,
+	})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "already exists")
+}
+
+func TestResolveIdentifier_ExternalRequiresID(t *testing.T) {
+	st := identifierStore(t)
+
+	_, err := ResolveIdentifier(IdentifierRequest{
+		Name:   "billing",
+		Method: IDMethodExternal,
+		Store:  st,
+	})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "id is required")
+}
+
+func TestResolveIdentifier_ExternalUsesNormalizedID(t *testing.T) {
+	st := identifierStore(t)
+
+	got, err := ResolveIdentifier(IdentifierRequest{
+		Name:   "Billing Export",
+		ID:     "EXT.User@123",
+		Method: IDMethodExternal,
+		Store:  st,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "ext-user-123-billing-export", got.Name)
+}
+
+func TestResolveIdentifier_UnknownMethodReturnsError(t *testing.T) {
+	st := identifierStore(t)
+
+	_, err := ResolveIdentifier(IdentifierRequest{
+		Name:   "billing",
+		Method: "unsupported",
+		Store:  st,
+	})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unsupported spec.id_method")
+}
+
+func TestResolveIdentifier_RejectsUnsafeOrUntrimmedValuesBeforeStoreUse(t *testing.T) {
+	tests := []struct {
+		name string
+		req  IdentifierRequest
+		want string
+	}{
+		{
+			name: "leading whitespace name",
+			req:  IdentifierRequest{Name: " billing", Method: IDMethodTimestamp},
+			want: "leading or trailing whitespace",
+		},
+		{
+			name: "trailing whitespace id",
+			req:  IdentifierRequest{Name: "billing", ID: "ext ", Method: IDMethodTimestamp},
+			want: "leading or trailing whitespace",
+		},
+		{
+			name: "path separator name",
+			req:  IdentifierRequest{Name: "billing/export", Method: IDMethodTimestamp},
+			want: "path separators",
+		},
+		{
+			name: "control character id",
+			req:  IdentifierRequest{Name: "billing", ID: "bad\nid", Method: IDMethodTimestamp},
+			want: "control characters",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ResolveIdentifier(tt.req)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.want)
+		})
+	}
+}
+
+func TestResolveIdentifier_NilStoreFailsGeneratedModes(t *testing.T) {
+	tests := []struct {
+		name   string
+		method string
+	}{
+		{name: "default timestamp"},
+		{name: "timestamp", method: IDMethodTimestamp},
+		{name: "counter", method: IDMethodCounter},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ResolveIdentifier(IdentifierRequest{
+				Name:   "billing",
+				Method: tt.method,
+				Now:    fixedIdentifierTime,
+			})
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "store required")
+		})
+	}
+}

--- a/internal/steps/spec/steps.go
+++ b/internal/steps/spec/steps.go
@@ -3,6 +3,8 @@ package spec
 import (
 	"fmt"
 
+	"github.com/jumppad-labs/spektacular/internal/artifact"
+	"github.com/jumppad-labs/spektacular/internal/config"
 	"github.com/jumppad-labs/spektacular/internal/stepkit"
 	"github.com/jumppad-labs/spektacular/internal/store"
 	"github.com/jumppad-labs/spektacular/internal/workflow"
@@ -11,6 +13,10 @@ import (
 // SpecFilePath returns the store-relative path for a spec file.
 func SpecFilePath(name string) string {
 	return "specs/" + name + ".md"
+}
+
+func specArtifactPath(cfg workflow.Config, name string) (string, error) {
+	return artifact.Path(cfg.Project, artifact.KindSpec, name)
 }
 
 // Steps returns the ordered step configs for a spec workflow.
@@ -73,7 +79,14 @@ func new() workflow.StepCallback {
 		if err != nil {
 			return "", err
 		}
-		if err := st.Write(SpecFilePath(name), []byte(rendered)); err != nil {
+		specPath, err := specArtifactPath(cfg, name)
+		if err != nil {
+			return "", err
+		}
+		if err := st.Write(specPath, []byte(rendered)); err != nil {
+			return "", err
+		}
+		if err := recordSpecRemote(data, st, cfg, name, []byte(rendered), true); err != nil {
 			return "", err
 		}
 		return "overview", nil
@@ -138,12 +151,43 @@ func verification() workflow.StepCallback {
 func finished() workflow.StepCallback {
 	return func(data workflow.Data, out workflow.ResultWriter, st store.Store, cfg workflow.Config) (string, error) {
 		specName := stepkit.GetString(data, "name")
-		specPath := SpecFilePath(specName)
 		if content := stepkit.GetString(data, "spec_template"); content != "" {
+			specPath, err := specArtifactPath(cfg, specName)
+			if err != nil {
+				return "", err
+			}
 			if err := st.Write(specPath, []byte(content)); err != nil {
+				return "", err
+			}
+			if err := recordSpecRemote(data, st, cfg, specName, []byte(content), true); err != nil {
 				return "", err
 			}
 		}
 		return "", writeStep("finished", "", "steps/spec/09-finished.md", data, out, st, cfg, nil)
 	}
+}
+
+func recordSpecRemote(data workflow.Data, st store.Store, cfg workflow.Config, name string, content []byte, required bool) error {
+	if cfg.Project.Artifacts.Backend != config.ArtifactBackendNotion {
+		return nil
+	}
+	value, ok := data.Get("remote")
+	if !ok || value == nil {
+		if required {
+			return fmt.Errorf("remote metadata is required in Notion mode")
+		}
+		return nil
+	}
+	remote, _, err := artifact.RemoteMetadataFromAny(value)
+	if err != nil {
+		return fmt.Errorf("reading remote metadata: %w", err)
+	}
+	if err := artifact.ValidateRemoteMetadata(remote); err != nil {
+		return err
+	}
+	if _, err := artifact.RecordPull(st, cfg.Project, artifact.KindSpec, name, content, remote); err != nil {
+		return err
+	}
+	data.Set("remote", nil)
+	return nil
 }

--- a/internal/steps/spec/strategy.go
+++ b/internal/steps/spec/strategy.go
@@ -3,7 +3,9 @@ package spec
 import (
 	"path/filepath"
 
+	"github.com/jumppad-labs/spektacular/internal/artifact"
 	"github.com/jumppad-labs/spektacular/internal/stepkit"
+	"github.com/jumppad-labs/spektacular/internal/workflow"
 )
 
 // strategy implements stepkit.PathStrategy for the spec workflow.
@@ -14,6 +16,17 @@ func (strategy) PrimaryPathField() string { return "spec_path" }
 func (strategy) PathVars(instanceName, storeRoot string) map[string]any {
 	return map[string]any{
 		"spec_path": filepath.Join(storeRoot, SpecFilePath(instanceName)),
+		"spec_name": instanceName,
+	}
+}
+
+func (s strategy) PathVarsWithConfig(instanceName, storeRoot string, cfg workflow.Config) map[string]any {
+	path, err := artifact.Path(cfg.Project, artifact.KindSpec, instanceName)
+	if err != nil {
+		return s.PathVars(instanceName, storeRoot)
+	}
+	return map[string]any{
+		"spec_path": filepath.Join(storeRoot, path),
 		"spec_name": instanceName,
 	}
 }

--- a/internal/workflow/workflow.go
+++ b/internal/workflow/workflow.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"time"
 
+	"github.com/jumppad-labs/spektacular/internal/config"
 	"github.com/jumppad-labs/spektacular/internal/store"
 	"github.com/looplab/fsm"
 )
@@ -14,6 +15,7 @@ import (
 type Config struct {
 	Command string
 	DryRun  bool
+	Project config.Config
 }
 
 // ResultWriter is implemented by the output writer and passed into step callbacks.

--- a/templates/.spektacular/.gitignore
+++ b/templates/.spektacular/.gitignore
@@ -2,6 +2,10 @@
 *.log
 .env
 
+# Spektacular Notion cache
+cache/notion/
+*.sync.tmp
+
 # Python
 __pycache__/
 *.py[cod]

--- a/templates/skills/workflows/spek-implement/SKILL.md
+++ b/templates/skills/workflows/spek-implement/SKILL.md
@@ -22,7 +22,19 @@ Plan name: $ARGUMENTS
 
 If no plan name was provided, check `.spektacular/state.json` for an active plan under `data.name`. If one exists, ask the user whether they want to implement that plan, offering the option to name a different one. If no active plan is found, ask the user which plan to implement before proceeding.
 
-The plan file must already exist at `.spektacular/plans/<plan_name>/plan.md`. If it does not, stop and tell the user to run `{{command}} plan` first.
+Before enforcing the plan-file precondition, run:
+
+```
+{{command}} notion status
+```
+
+If the returned `status` is not `configured`, the plan file must already exist at `.spektacular/plans/<plan_name>/plan.md`. If it does not, stop and tell the user to run `{{command}} plan` first.
+
+If Notion mode is configured, the plan cache must exist under `.spektacular/cache/notion/plans/<plan_name>/plan.md`. If it is missing, fetch the Plan page, `context.md`, and `research.md` child pages through Notion MCP and record them with `{{command}} notion cache pull`. You can pull by Notion URL, page ID, or Spektacular external ID when another user or agent already created the work.
+
+During implementation, any step that changes a cached artifact must sync before advancing. Run `{{command}} notion cache prepare-push` with the latest Notion `remote_version`; if it returns `ready`, update Notion through MCP and then run `{{command}} notion cache commit-push` with the returned metadata. If it returns `merge_required`, stop and surface the merge request to the user/agent. After resolution, run `{{command}} notion cache resolve-merge`, retry `prepare-push`, update Notion, and then commit the returned metadata.
+
+Doctor/setup flow: if Notion databases are not linked or validation reports issues, run `{{command}} notion link` to validate existing data sources and `{{command}} notion doctor` for fixable/blocking reports. Only apply additive doctor repairs after explicit user approval.
 
 Start the implement workflow by running:
 

--- a/templates/skills/workflows/spek-new/SKILL.md
+++ b/templates/skills/workflows/spek-new/SKILL.md
@@ -34,6 +34,28 @@ External systems may also supply an identifier with:
 {{command}} spec new --data '{"name": "<spec_name>", "id": "<external_id>"}'
 ```
 
+## Notion artifact mode
+
+Before starting, run:
+
+```
+{{command}} notion status
+```
+
+If the returned `status` is `configured`, artifacts are Notion-backed. Use Notion MCP to create or fetch the Spec page first, then read its required `Spec ID` auto-increment value and returned metadata. Start the workflow with the Notion ID as the external identifier and include the normalized remote metadata:
+
+```
+{{command}} spec new --data '{"name":"<spec_name>","remote":{"notion_url":"<page_url>","page_id":"<page_id>","data_source_url":"<specs_data_source>","external_id":"<spec_id>","remote_version":"<last_edited_time>","title":"<title>"}}'
+```
+
+When the final spec content is ready, update the Notion Spec page body through Notion MCP first. Then submit the same content to Spektacular with the returned remote metadata so the local cache and manifest are aligned:
+
+```
+{{command}} spec goto --data '{"step":"finished","remote":{"notion_url":"<page_url>","page_id":"<page_id>","data_source_url":"<specs_data_source>","external_id":"<spec_id>","remote_version":"<new_last_edited_time>","title":"<title>"}}' --file .spektacular/tmp/spec_template.md
+```
+
+If Notion reports that the page changed since the local baseline, stop and use `{{command}} notion cache prepare-push` to surface the merge request. Present the baseline, local, and remote content to the user/agent, run `{{command}} notion cache resolve-merge` after resolution, then retry the Notion update.
+
 The CLI may normalize and prefix the requested name. Always use the returned `spec_name` and `spec_path` as the source of truth for follow-up workflows.
 
 This creates the spec file and state file automatically and returns the first `instruction`. From that point on, follow the loop above: do what the instruction says, then call `{{command}} spec goto --data '{"step":"<next_step>"}'` to get the next one. Do not invent step names — every instruction tells you the exact `goto` command to run next.

--- a/templates/skills/workflows/spek-new/SKILL.md
+++ b/templates/skills/workflows/spek-new/SKILL.md
@@ -5,7 +5,7 @@ description: Create a new Specification for a feature.
 
 # What this skill does
 
-This skill drives a **multi-step interactive workflow** that produces a complete specification file in `.spektacular/specs/<name>.md`. The workflow is owned by the `{{command}}` CLI, not by you — the CLI is the state machine and you are the executor.
+This skill drives a **multi-step interactive workflow** that produces a complete specification file at the `spec_path` returned by the CLI. The workflow is owned by the `{{command}}` CLI, not by you — the CLI is the state machine and you are the executor.
 
 On each turn, the CLI returns JSON containing an `instruction` field. That instruction describes exactly one step (e.g. overview, requirements, acceptance criteria, …). You must:
 
@@ -27,5 +27,13 @@ Start the spec workflow by running:
 ```
 {{command}} spec new --data '{"name": "<spec_name>"}'
 ```
+
+External systems may also supply an identifier with:
+
+```
+{{command}} spec new --data '{"name": "<spec_name>", "id": "<external_id>"}'
+```
+
+The CLI may normalize and prefix the requested name. Always use the returned `spec_name` and `spec_path` as the source of truth for follow-up workflows.
 
 This creates the spec file and state file automatically and returns the first `instruction`. From that point on, follow the loop above: do what the instruction says, then call `{{command}} spec goto --data '{"step":"<next_step>"}'` to get the next one. Do not invent step names — every instruction tells you the exact `goto` command to run next.

--- a/templates/skills/workflows/spek-plan/SKILL.md
+++ b/templates/skills/workflows/spek-plan/SKILL.md
@@ -28,4 +28,28 @@ Start the plan workflow by running:
 {{command}} plan new --data '{"name": "<spec_name>"}'
 ```
 
+## Notion artifact mode
+
+Before starting, run:
+
+```
+{{command}} notion status
+```
+
+If the returned `status` is `configured`, artifacts are Notion-backed. Ensure the Spec cache exists before planning. If another user or agent already created the spec, locate it by Notion URL, page ID, or external Spec ID; if it is missing locally, fetch the Spec page through Notion MCP and record it:
+
+```
+{{command}} notion cache pull --data '{"kind":"spec","name":"<spec_name>","content":"<spec_markdown>","remote":{"notion_url":"<page_url>","page_id":"<page_id>","data_source_url":"<specs_data_source>","external_id":"<spec_id>","remote_version":"<last_edited_time>","title":"<title>"}}'
+```
+
+Create or fetch the Plan row through Notion MCP before the write steps. Use the required `Plan ID` auto-increment value as `remote.external_id`. Create or fetch child pages for `context.md` and `research.md` under the Plan page. When submitting each artifact-changing step, update Notion first, then pass the returned metadata with the file:
+
+```
+{{command}} plan goto --data '{"step":"write_plan","remote":{"notion_url":"<plan_page_url>","page_id":"<plan_page_id>","data_source_url":"<plans_data_source>","external_id":"<plan_id>","remote_version":"<new_last_edited_time>","title":"<title>"}}' --file .spektacular/tmp/plan_template.md
+{{command}} plan goto --data '{"step":"write_context","context_remote":{"notion_url":"<context_page_url>","page_id":"<context_page_id>","data_source_url":"<plans_data_source>","external_id":"<context_id>","remote_version":"<new_last_edited_time>","title":"context.md"}}' --file .spektacular/tmp/context_template.md
+{{command}} plan goto --data '{"step":"write_research","research_remote":{"notion_url":"<research_page_url>","page_id":"<research_page_id>","data_source_url":"<plans_data_source>","external_id":"<research_id>","remote_version":"<new_last_edited_time>","title":"research.md"}}' --file .spektacular/tmp/research_template.md
+```
+
+Before any Notion update, use `{{command}} notion cache prepare-push` with the latest Notion `remote_version`. If it returns `merge_required`, stop and present the merge request; after resolution, run `{{command}} notion cache resolve-merge` and retry.
+
 This creates the plan file and state file automatically and returns the first `instruction`. From that point on, follow the loop above: do what the instruction says, then call `{{command}} plan goto --data '{"step":"<next_step>"}'` to get the next one. Do not invent step names — every instruction tells you the exact `goto` command to run next.

--- a/templates/steps/plan/13-verification.md
+++ b/templates/steps/plan/13-verification.md
@@ -88,3 +88,5 @@ Do **not** write directly to `{{plan_path}}` — spektacular owns that file. Ins
 ```
 
 Spektacular reads the file and stores its contents under the workflow key derived from the filename (`plan_template`), then writes the final plan to `{{plan_path}}`. The `--file` flag is required here (not `--stdin`) because large plans exceed the tool-call size limit when inlined as a heredoc.
+
+If `{{config.command}} notion status` reports Notion mode as configured, update the matching Notion artifact through MCP before each write step and include the returned metadata in the `plan goto` `--data` payload: `remote` for plan.md, `context_remote` for context.md, and `research_remote` for research.md. If `notion cache prepare-push` returns `merge_required`, stop and resolve the merge before advancing.

--- a/templates/steps/spec/08-verification.md
+++ b/templates/steps/spec/08-verification.md
@@ -42,3 +42,4 @@ Once the user is happy, produce the final complete spec. Use the `Write` tool to
 
 Spektacular reads the file and writes the final spec to the store. The `--file` flag is required here (not `--stdin`) because large specs exceed the tool-call size limit when inlined as a heredoc.
 
+If `{{config.command}} notion status` reports Notion mode as configured, update the Notion Spec page through Notion MCP before submitting this file. Include the returned remote metadata in the `spec goto` `--data` payload so Spektacular records the cache baseline. If `notion cache prepare-push` returns `merge_required`, stop and resolve that merge before advancing.

--- a/tests/harbor/spec-workflow/instruction.md
+++ b/tests/harbor/spec-workflow/instruction.md
@@ -8,22 +8,23 @@ The binary is already installed at `/usr/local/bin/spektacular`.
 First initialize the project:
 
 ```bash
-spektacular init claude
+spektacular init codex
 ```
 
 ## Task
 
 Create a specification for a **user authentication feature using JWT tokens** by
-using the `/spek:new` skill that was installed during init.
+driving the native `spektacular spec` workflow.
 
-Run the skill:
+Start the workflow:
 
+```bash
+spektacular spec new --data '{"name":"user-auth"}'
 ```
-/spek:new user-auth
-```
 
-The skill will guide you through the full spec workflow. Follow each instruction
-it gives you.
+The CLI returns JSON with a normalized, prefixed `spec_name` and `spec_path`.
+Use those returned values as the source of truth. Follow each instruction the
+CLI gives you, and advance with `spektacular spec goto --data '{"step":"..."}'`.
 
 When writing content for each section, use these details about the feature:
 - **What**: Stateless user authentication using JWT access and refresh tokens
@@ -44,5 +45,5 @@ cp -r /app/.spektacular /logs/artifacts/spektacular
 
 - The workflow reaches the `finished` or `done` state
 - All steps appear in the completed_steps list
-- The spec file at `.spektacular/specs/user-auth.md` contains content
+- The spec file at the returned `spec_path` contains content
 - Each spec section has meaningful, non-placeholder text

--- a/tests/harbor/spec-workflow/tests/test_spec_workflow.py
+++ b/tests/harbor/spec-workflow/tests/test_spec_workflow.py
@@ -13,8 +13,7 @@ from pathlib import Path
 PROJECT_DIR = Path("/app")
 SPEK_DIR = PROJECT_DIR / ".spektacular"
 STATE_FILE = SPEK_DIR / "state.json"
-SPEC_FILE = SPEK_DIR / "specs" / "user-auth.md"
-AGENT_TRANSCRIPT = Path("/logs/agent/claude-code.txt")
+AGENT_LOG_DIR = Path("/logs/agent")
 
 # The canonical step order as defined by the state machine in
 # internal/steps/spec/steps.go → Steps().
@@ -44,9 +43,17 @@ def load_state() -> dict:
     return json.loads(STATE_FILE.read_text())
 
 
+def spec_file_path() -> Path:
+    state = load_state()
+    spec_name = (state.get("data") or {}).get("name")
+    assert spec_name, "state.json has no data.name — cannot resolve spec file"
+    return SPEK_DIR / "specs" / f"{spec_name}.md"
+
+
 def load_spec() -> str:
-    assert SPEC_FILE.exists(), f"Spec file not found at {SPEC_FILE}"
-    return SPEC_FILE.read_text()
+    path = spec_file_path()
+    assert path.exists(), f"Spec file not found at {path}"
+    return path.read_text()
 
 
 def parse_sections(spec_text: str) -> dict[str, str]:
@@ -83,27 +90,34 @@ def extract_tool_calls() -> list[dict]:
 
     Each entry is {"command": "…"} for Bash tool_use blocks.
     """
-    assert AGENT_TRANSCRIPT.exists(), (
-        f"Agent transcript not found at {AGENT_TRANSCRIPT}"
-    )
+    transcripts = sorted(AGENT_LOG_DIR.glob("*.txt"))
+    assert transcripts, f"No agent transcripts found under {AGENT_LOG_DIR}"
 
     calls = []
-    for line in AGENT_TRANSCRIPT.read_text().splitlines():
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            obj = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-        if obj.get("type") != "assistant":
-            continue
-        msg = obj.get("message", {})
-        for block in msg.get("content", []):
-            if block.get("type") == "tool_use" and block.get("name") == "Bash":
-                cmd = block.get("input", {}).get("command", "")
-                if cmd:
-                    calls.append({"command": cmd})
+    for transcript in transcripts:
+        for line in transcript.read_text().splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if obj.get("type") == "item.completed":
+                item = obj.get("item", {})
+                if item.get("type") == "command_execution":
+                    cmd = item.get("command", "")
+                    if cmd:
+                        calls.append({"command": cmd})
+                    continue
+            if obj.get("type") != "assistant":
+                continue
+            msg = obj.get("message", {})
+            for block in msg.get("content", []):
+                if block.get("type") == "tool_use" and block.get("name") == "Bash":
+                    cmd = block.get("input", {}).get("command", "")
+                    if cmd:
+                        calls.append({"command": cmd})
     return calls
 
 
@@ -118,9 +132,18 @@ def find_spektacular_calls(tool_calls: list[dict]) -> list[str]:
         if "spektacular spec new" in cmd:
             results.append("spec new")
         elif "spektacular spec goto" in cmd:
-            m = re.search(r'"step"\s*:\s*"(\w+)"', cmd)
+            normalized = cmd.replace('\\"', '"').replace("\\'", "'")
+            m = re.search(r'["\']step["\']\s*:\s*["\']([a-z_]+)["\']', normalized)
             if m:
                 results.append(f"spec goto {m.group(1)}")
+                continue
+
+            for step in EXPECTED_STEP_ORDER:
+                if step == "new":
+                    continue
+                if re.search(rf"\b{re.escape(step)}\b", normalized):
+                    results.append(f"spec goto {step}")
+                    break
     return results
 
 
@@ -137,7 +160,8 @@ class TestWorkflow:
 
     def test_spec_file_exists(self):
         """The spec markdown file was created."""
-        assert SPEC_FILE.exists(), f"Spec file not found at {SPEC_FILE}"
+        path = spec_file_path()
+        assert path.exists(), f"Spec file not found at {path}"
 
     def test_workflow_reached_finished(self):
         """Workflow current_step is finished or done."""


### PR DESCRIPTION
## Why
This adds a Notion-backed artifact workflow for teams that want specs, context, research, and plans to live in Notion while agents continue to work through Spektacular commands and a local cache. The binary deliberately does not call Notion directly; agents use Notion MCP for reads and writes, then pass snapshots and remote metadata into Spektacular so auth, permissions, and Notion mutations stay at the MCP boundary.

## Stacking note
This PR builds on #4 because Notion mode requires externally owned spec IDs. Until #4 is merged and this branch is updated, GitHub will show the configurable spec ID commit in this diff. The Notion backend implementation is commit `1846f4d`.

## What changed
- Adds `artifacts.backend: notion` configuration with required linked Specs and Plans data sources, cache settings, and external ID properties.
- Requires `spec.id_method: external` in Notion mode so the Notion auto-increment ID is the source of truth for new specs.
- Adds `spektacular notion init`, `link`, `doctor`, and `status` commands. `init` prepares MCP setup instructions, `link` validates existing data source snapshots and writes config, `doctor` reports schema issues and prepares approved additive MCP repair instructions, and `status` summarizes the linked backend.
- Adds an ignored Notion working cache under `.spektacular/cache/notion` plus manifest tracking for local paths, remote Notion IDs/URLs, external IDs, remote versions, dirty state, and conflict state.
- Adds `spektacular notion cache pull`, `status`, `prepare-push`, `commit-push`, and `resolve-merge` to support explicit bidirectional sync through Notion MCP.
- Routes `spec`, `plan`, and `implement` workflows through cached artifact paths when Notion mode is enabled while preserving local file behavior for the default backend.
- Updates `$spek-new`, `$spek-plan`, `$spek-implement`, templates, README, changelog, and workflow verification steps so agents surface sync requirements and merge-resolution needs.

## Review notes
- No direct Notion API client is introduced in the binary; all Notion reads and writes remain MCP-driven.
- Knowledge artifacts are still out of scope. This PR covers spec, context, research, and plan artifacts.
- `doctor --apply` prepares safe additive update instructions for Notion MCP instead of mutating Notion itself.
- Live Notion MCP coverage remains manual/fixture-backed; deterministic command and unit tests cover config, schema validation, cache sync contracts, conflict output, and workflow startup/cache behavior.

## Validation
- `GOCACHE=/private/tmp/spektacular-go-cache make test`
- `GOCACHE=/private/tmp/spektacular-go-cache make lint`